### PR TITLE
feat: add on_close hook to defer window close across all backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "confirm_before_quit_runtime"
+version = "0.1.0"
+dependencies = [
+ "laufey",
+ "tokio",
+]
+
+[[package]]
 name = "cooked-waker"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "winit",
     "backend-winit-common",
     "examples/hello",
+    "examples/confirm_before_quit",
     "examples/ios_hello",
     "examples/binding_test",
     "examples/ddcore",

--- a/backend-winit-common/src/lib.rs
+++ b/backend-winit-common/src/lib.rs
@@ -2324,11 +2324,10 @@ macro_rules! define_common_backend_fns {
           window_id,
         );
         if proceed {
-          let _ = state.proxy().send_event(
-            <$B as $crate::BackendAccess>::common_event(
-              $crate::CommonEvent::CloseWindow { window_id },
-            ),
-          );
+          // Route through the real close entry point (which queues
+          // CommonEvent::CloseWindow) rather than re-inlining it, so the
+          // hook can't silently diverge from the shipping close path.
+          unsafe { backend_close_window(_data, window_id) };
           false
         } else {
           true
@@ -3660,8 +3659,11 @@ pub fn dispatch_close_requested_event(
   handlers: &EventHandlers,
   window_id: u32,
 ) -> bool {
-  let handler = handlers.close_requested_handler.lock().unwrap();
-  if let Some((cb, user_data)) = *handler {
+  // Copy the handler out and release the lock before invoking it: the
+  // handler may block (e.g. a modal confirm dialog) and pump OS events,
+  // which can re-enter this dispatch on the same thread.
+  let handler = *handlers.close_requested_handler.lock().unwrap();
+  if let Some((cb, user_data)) = handler {
     unsafe {
       cb(user_data as *mut c_void, window_id);
     }

--- a/backend-winit-common/src/lib.rs
+++ b/backend-winit-common/src/lib.rs
@@ -32,8 +32,8 @@ use winit::window::{Window, WindowLevel};
 // Must match `LAUFEY_API_VERSION` in capi/include/laufey.h (and capi/src/lib.rs).
 // Bumping this in lockstep with the capi is mandatory: the capi's `init_api`
 // rejects any backend whose reported `version` differs, and the vtable layout
-// below must match the v29 `laufey_backend_api`.
-pub const LAUFEY_API_VERSION: u32 = 30;
+// below must match the `laufey_backend_api` struct as of this version.
+pub const LAUFEY_API_VERSION: u32 = 31;
 
 /// Creation-time window style flags (mirror `LAUFEY_WINDOW_FLAG_*` in laufey.h).
 pub const LAUFEY_WINDOW_FLAG_FRAMELESS: u32 = 1 << 0;
@@ -528,6 +528,10 @@ pub struct LaufeyBackendApi {
   // --- Test hooks (API >= 30) ---
   pub test_click_menu_item:
     Option<unsafe extern "C" fn(*mut c_void, *const c_char) -> bool>,
+
+  // --- Test hook, API >= 31 ---
+  pub test_trigger_close_requested:
+    Option<unsafe extern "C" fn(*mut c_void, u32) -> bool>,
 }
 
 unsafe impl Send for LaufeyBackendApi {}
@@ -1159,6 +1163,8 @@ pub fn create_api_base() -> LaufeyBackendApi {
     get_window_opacity: None,
     // Test hooks (API >= 30).
     test_click_menu_item: None,
+    // Test hook, API >= 31.
+    test_trigger_close_requested: None,
   }
 }
 
@@ -2308,6 +2314,30 @@ macro_rules! define_common_backend_fns {
       }
     }
 
+    unsafe extern "C" fn backend_test_trigger_close_requested(
+      _data: *mut ::std::ffi::c_void,
+      window_id: u32,
+    ) -> bool {
+      if let Some(state) = <$B as $crate::BackendAccess>::get() {
+        let proceed = $crate::dispatch_close_requested_event(
+          &state.common().handlers,
+          window_id,
+        );
+        if proceed {
+          let _ = state.proxy().send_event(
+            <$B as $crate::BackendAccess>::common_event(
+              $crate::CommonEvent::CloseWindow { window_id },
+            ),
+          );
+          false
+        } else {
+          true
+        }
+      } else {
+        true
+      }
+    }
+
     unsafe extern "C" fn backend_show_dialog(
       _data: *mut ::std::ffi::c_void,
       _window_id: u32,
@@ -2849,6 +2879,8 @@ macro_rules! fill_common_api {
     $api.read_clipboard_text = Some(backend_read_clipboard_text);
     $api.write_clipboard_text = Some(backend_write_clipboard_text);
     $api.test_click_menu_item = Some(backend_test_click_menu_item);
+    $api.test_trigger_close_requested =
+      Some(backend_test_trigger_close_requested);
   };
 }
 
@@ -3620,16 +3652,22 @@ pub fn dispatch_move_event(
   }
 }
 
+/// Fires the close-requested handler for `window_id`, if any, and reports
+/// whether the caller should proceed to actually close the window. A
+/// registered handler always defers the close (the app decides later, out
+/// of band, by calling `close_window`); no handler means proceed.
 pub fn dispatch_close_requested_event(
   handlers: &EventHandlers,
   window_id: u32,
-) {
+) -> bool {
   let handler = handlers.close_requested_handler.lock().unwrap();
   if let Some((cb, user_data)) = *handler {
     unsafe {
       cb(user_data as *mut c_void, window_id);
     }
+    return false;
   }
+  true
 }
 
 // --- Runtime loading ---

--- a/capi/include/laufey.h
+++ b/capi/include/laufey.h
@@ -253,6 +253,13 @@ typedef void (*laufey_keyboard_event_fn)(
 // actually close it. Doing nothing leaves the window open indefinitely.
 // With no handler registered, the window closes immediately on click, same
 // as backends predating API 31.
+//
+// The defer is PROCESS-WIDE, not per-window: once registered, the handler
+// receives (and holds open) EVERY window's close click. A handler that only
+// wants to intercept some windows must call close_window(window_id) itself
+// for the rest, or they become unclosable. (The Rust capi's per-window
+// on_close_requested wrapper does this automatically for windows without a
+// registered handler.)
 typedef void (*laufey_close_requested_fn)(void* user_data, uint32_t window_id);
 
 // Callback fired when a window finishes loading a navigation (the document and
@@ -748,13 +755,18 @@ struct laufey_backend_api {
   bool (*test_click_menu_item)(void* backend_data, const char* item_id);
 
   // Test-only. Synthesizes a close-requested event on window_id through the
-  // same dispatch path a real OS close click uses. Returns true if the
-  // window is still open afterward (a registered close_requested_handler
-  // deferred the close), false if it closed immediately (no handler was
-  // registered). Same best-effort-probe convention as test_click_menu_item:
-  // also returns true (indistinguishable from "still open") if the backend
-  // doesn't implement this hook (API < 31) or window_id is unknown. NULL on
-  // backends that don't implement it.
+  // same dispatch code a real OS close click runs. Returns true if a
+  // registered close_requested_handler deferred the close (the window is
+  // still open), false if the close proceeded (no handler was registered).
+  // "Proceeded" means initiated, not necessarily completed: some backends
+  // (winit, CEF) queue the actual close, so callers should poll window
+  // state rather than assert immediately after a false return. Two
+  // deliberate differences from a real close click: the handler runs
+  // synchronously on the CALLING thread, not the backend UI thread, and
+  // window_id is not validated -- an unknown id still reaches a registered
+  // handler (and returns false with no effect otherwise). NULL on backends
+  // that don't implement it (API < 31); callers should treat a NULL hook as
+  // unavailable, like test_click_menu_item.
   bool (*test_trigger_close_requested)(void* backend_data, uint32_t window_id);
 };
 

--- a/capi/include/laufey.h
+++ b/capi/include/laufey.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-#define LAUFEY_API_VERSION 30
+#define LAUFEY_API_VERSION 31
 
 // Window handle types for get_window_handle_type
 #define LAUFEY_WINDOW_HANDLE_UNKNOWN 0
@@ -244,7 +244,15 @@ typedef void (*laufey_keyboard_event_fn)(
     uint32_t modifiers,  // bitmask of LAUFEY_MOD_* flags
     bool repeat);
 
-// Callback for window close requested events.
+// Callback for window close requested events. Registering this handler
+// (API >= 31) makes the backend WAIT: the window does not close on its own
+// when the user clicks the close button. Do whatever work is needed --
+// flush writes, close file handles, ask the user -- then call
+// close_window(window_id) -- the existing API, safe to call from any
+// thread, at any later time, synchronously or asynchronously -- to
+// actually close it. Doing nothing leaves the window open indefinitely.
+// With no handler registered, the window closes immediately on click, same
+// as backends predating API 31.
 typedef void (*laufey_close_requested_fn)(void* user_data, uint32_t window_id);
 
 // Callback fired when a window finishes loading a navigation (the document and
@@ -435,7 +443,9 @@ struct laufey_backend_api {
   void (*set_move_handler)(void* backend_data, laufey_move_fn handler,
                            void* user_data);
 
-  // Register a handler for window close requested events.
+  // Register a handler for window close requested events. See
+  // laufey_close_requested_fn's doc comment for the defer-until-close_window
+  // contract (API >= 31).
   void (*set_close_requested_handler)(void* backend_data,
                                       laufey_close_requested_fn handler,
                                       void* user_data);
@@ -736,6 +746,16 @@ struct laufey_backend_api {
   // exercise menu/tray click round-trips without OS-level input injection or
   // main-thread UI access. NULL on backends that don't implement it.
   bool (*test_click_menu_item)(void* backend_data, const char* item_id);
+
+  // Test-only. Synthesizes a close-requested event on window_id through the
+  // same dispatch path a real OS close click uses. Returns true if the
+  // window is still open afterward (a registered close_requested_handler
+  // deferred the close), false if it closed immediately (no handler was
+  // registered). Same best-effort-probe convention as test_click_menu_item:
+  // also returns true (indistinguishable from "still open") if the backend
+  // doesn't implement this hook (API < 31) or window_id is unknown. NULL on
+  // backends that don't implement it.
+  bool (*test_trigger_close_requested)(void* backend_data, uint32_t window_id);
 };
 
 #ifdef __cplusplus

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -96,6 +96,12 @@ fn api() -> &'static LaufeyBackendApi {
   BACKEND_API.get().expect("Backend API not initialized")
 }
 
+// Non-panicking variant for callback paths that may run before (or without)
+// init_api — e.g. unit tests driving trampolines directly.
+pub(crate) fn try_api() -> Option<&'static LaufeyBackendApi> {
+  BACKEND_API.get().copied()
+}
+
 fn bindings() -> &'static Mutex<HashMap<u32, HashMap<String, BindingHandler>>> {
   BINDINGS.get_or_init(|| Mutex::new(HashMap::new()))
 }
@@ -1089,6 +1095,11 @@ impl Window {
   /// `Window::close()` (synchronously in the handler, or later from any
   /// thread, e.g. after a confirm dialog) to actually close it.
   ///
+  /// Per-window: only *this* window is held open. Other windows without
+  /// their own handler keep closing immediately, even though the backend's
+  /// C-level defer contract is process-wide (the capi completes the close
+  /// on their behalf -- see `close_requested_trampoline`).
+  ///
   /// Fires only for the window's own close control (title bar button,
   /// `Alt+F4`, a window manager's close action) -- never `Cmd+Q`, a "Quit"
   /// menu/tray item, or any other app-level termination. See `docs/c-abi.md`
@@ -1397,11 +1408,18 @@ pub fn test_click_menu_item(item_id: &str) -> bool {
 }
 
 /// Test-only. Synthesizes a close-requested event on `window_id` through the
-/// same dispatch path a real OS close click uses. Returns `true` if the
-/// window is still open afterward (an [`Window::on_close_requested`] handler
-/// deferred the close), `false` if it closed immediately (no handler was
-/// registered, or the backend does not implement the test hook, API < 31 --
-/// indistinguishable from "closed").
+/// same dispatch code a real OS close click runs. Returns `true` if an
+/// [`Window::on_close_requested`] handler deferred the close (the window is
+/// still open), `false` if the close proceeded (no handler was registered,
+/// or the backend does not implement the test hook -- indistinguishable
+/// cases). "Proceeded" means the close was initiated, not necessarily
+/// completed: some backends (winit, CEF) queue the actual close, so poll
+/// window state rather than asserting immediately after a `false` return.
+///
+/// Two deliberate differences from a real close click: the handler runs
+/// synchronously on the *calling* thread, not the backend UI thread, and
+/// `window_id` is not validated -- an unknown id still reaches a registered
+/// handler.
 ///
 /// Intended for automated e2e tests. See `examples/native_e2e` and
 /// `docs/e2e-testing.md`.

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -29,7 +29,7 @@ pub use mouse::*;
 /// (`github.com/denoland/laufey/releases/tag/v{VERSION}`).
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub const LAUFEY_API_VERSION: u32 = 30;
+pub const LAUFEY_API_VERSION: u32 = 31;
 
 /// Creation-time window style flags for [`Window::new_with_options`].
 /// Mirror the `LAUFEY_WINDOW_FLAG_*` constants in `laufey.h`.
@@ -1084,6 +1084,24 @@ impl Window {
     self
   }
 
+  /// Registering this holds the window open: it won't close on its own
+  /// once this fires. Doing nothing in the handler leaves it open; call
+  /// `Window::close()` (synchronously in the handler, or later from any
+  /// thread, e.g. after a confirm dialog) to actually close it.
+  ///
+  /// Fires only for the window's own close control (title bar button,
+  /// `Alt+F4`, a window manager's close action) -- never `Cmd+Q`, a "Quit"
+  /// menu/tray item, or any other app-level termination. See `docs/c-abi.md`
+  /// for why that's deliberate.
+  ///
+  /// The handler fires synchronously on the platform's native UI thread
+  /// (e.g. AppKit's `windowShouldClose:`), which has **no ambient Tokio
+  /// reactor** -- a bare `tokio::spawn` inside it panics. To resolve
+  /// asynchronously, capture a `tokio::runtime::Handle` from inside your
+  /// runtime beforehand and call `handle.spawn(...)` from the handler
+  /// instead; a `Handle` works from any thread, including this one. For a
+  /// synchronous confirm dialog, `Window::confirm()` can be called directly
+  /// in the handler instead.
   pub fn on_close_requested<F>(self, handler: F) -> Self
   where
     F: Fn(CloseRequestedEvent) + Send + Sync + 'static,
@@ -1376,6 +1394,23 @@ pub fn test_click_menu_item(item_id: &str) -> bool {
   };
   // SAFETY: `c_id` outlives the call; the backend only reads the string.
   unsafe { f(api.backend_data, c_id.as_ptr()) }
+}
+
+/// Test-only. Synthesizes a close-requested event on `window_id` through the
+/// same dispatch path a real OS close click uses. Returns `true` if the
+/// window is still open afterward (an [`Window::on_close_requested`] handler
+/// deferred the close), `false` if it closed immediately (no handler was
+/// registered, or the backend does not implement the test hook, API < 31 --
+/// indistinguishable from "closed").
+///
+/// Intended for automated e2e tests. See `examples/native_e2e` and
+/// `docs/e2e-testing.md`.
+pub fn test_trigger_close_requested(window_id: u32) -> bool {
+  let api = api();
+  let Some(f) = api.test_trigger_close_requested else {
+    return false;
+  };
+  unsafe { f(api.backend_data, window_id) }
 }
 
 /// A menu item in an application menu template.

--- a/capi/src/mouse.rs
+++ b/capi/src/mouse.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::ffi::c_int;
 use std::ffi::c_void;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::{api, KeyModifiers};
 
@@ -86,7 +86,10 @@ impl MouseButton {
   }
 }
 
-type HandlerMap<T> = Mutex<HashMap<u32, Box<dyn Fn(T) + Send + Sync>>>;
+// Arc, not Box: trampolines clone the handler out and release the map lock
+// before invoking it, so a handler that blocks (e.g. a modal confirm dialog
+// whose event pump re-enters a trampoline) can't self-deadlock on the map.
+type HandlerMap<T> = Mutex<HashMap<u32, Arc<dyn Fn(T) + Send + Sync>>>;
 
 macro_rules! handler_store {
   ($fn_name:ident, $event_type:ty) => {
@@ -194,7 +197,7 @@ where
   mouse_click_handlers()
     .lock()
     .unwrap()
-    .insert(window_id, Box::new(handler));
+    .insert(window_id, Arc::new(handler));
 }
 
 // --- Mouse move ---
@@ -235,7 +238,7 @@ where
   mouse_move_handlers()
     .lock()
     .unwrap()
-    .insert(window_id, Box::new(handler));
+    .insert(window_id, Arc::new(handler));
 }
 
 // --- Wheel events ---
@@ -302,7 +305,7 @@ where
   wheel_handlers()
     .lock()
     .unwrap()
-    .insert(window_id, Box::new(handler));
+    .insert(window_id, Arc::new(handler));
 }
 
 // --- Cursor enter/leave events ---
@@ -346,7 +349,7 @@ where
   cursor_enter_leave_handlers()
     .lock()
     .unwrap()
-    .insert(window_id, Box::new(handler));
+    .insert(window_id, Arc::new(handler));
 }
 
 // --- Focused events ---
@@ -381,7 +384,7 @@ where
   focused_handlers()
     .lock()
     .unwrap()
-    .insert(window_id, Box::new(handler));
+    .insert(window_id, Arc::new(handler));
 }
 
 // --- Resize events ---
@@ -419,7 +422,7 @@ where
   resize_handlers()
     .lock()
     .unwrap()
-    .insert(window_id, Box::new(handler));
+    .insert(window_id, Arc::new(handler));
 }
 
 // --- Move events ---
@@ -453,7 +456,7 @@ where
   move_handlers()
     .lock()
     .unwrap()
-    .insert(window_id, Box::new(handler));
+    .insert(window_id, Arc::new(handler));
 }
 
 // --- Close requested events ---
@@ -463,17 +466,37 @@ pub struct CloseRequestedEvent {
   pub window_id: u32,
 }
 
-// See `Window::on_close_requested` for the public contract; this just dispatches to
-// the registered handler for `window_id`, if any.
+// See `Window::on_close_requested` for the public contract. The backend's
+// defer decision is process-wide (it defers every window's close once this
+// trampoline is registered), while `on_close_requested` handlers are
+// per-window — so a window *without* a handler must have its close completed
+// here, or it would be left permanently unclosable.
 unsafe extern "C" fn close_requested_trampoline(
   _user_data: *mut c_void,
   window_id: u32,
 ) {
   let event = CloseRequestedEvent { window_id };
 
-  let guard = close_requested_handlers().lock().unwrap();
-  if let Some(handler) = guard.get(&window_id) {
-    handler(event);
+  // Clone the handler out and release the map lock before invoking: the
+  // handler may block (e.g. `Window::confirm()`), and its modal event pump
+  // can deliver another close-requested re-entrantly on this same thread.
+  let handler = close_requested_handlers()
+    .lock()
+    .unwrap()
+    .get(&window_id)
+    .cloned();
+  match handler {
+    Some(handler) => handler(event),
+    None => {
+      // No handler for this window: the backend deferred on our behalf, so
+      // complete the close ourselves to preserve the no-handler behavior
+      // (window closes immediately on click).
+      if let Some(api) = crate::try_api() {
+        if let Some(f) = api.close_window {
+          unsafe { f(api.backend_data, window_id) };
+        }
+      }
+    }
   }
 }
 
@@ -485,7 +508,7 @@ where
   close_requested_handlers()
     .lock()
     .unwrap()
-    .insert(window_id, Box::new(handler));
+    .insert(window_id, Arc::new(handler));
 }
 
 // --- Page load events ---
@@ -518,7 +541,7 @@ where
   page_load_handlers()
     .lock()
     .unwrap()
-    .insert(window_id, Box::new(handler));
+    .insert(window_id, Arc::new(handler));
 }
 
 #[cfg(test)]
@@ -736,9 +759,48 @@ mod tests {
   #[test]
   fn close_requested_no_handler_is_noop() {
     // No handler registered for this window_id: dispatching must not panic
-    // and must not touch any other window's handler.
-    close_requested_handlers().lock().unwrap().clear();
+    // and must not touch any other window's handler. (With a real backend
+    // API table registered, this branch would instead complete the close
+    // via close_window — untestable here without one; try_api() is None.)
+    // Remove only our own id: tests run in parallel over a shared map, so
+    // clear() here could wipe another test's handler mid-run.
+    close_requested_handlers().lock().unwrap().remove(&9001);
     unsafe { close_requested_trampoline(std::ptr::null_mut(), 9001) };
+  }
+
+  #[test]
+  fn close_requested_handler_can_reenter_dispatch() {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    let window_id = 7777;
+    let depth = Arc::new(AtomicU32::new(0));
+
+    {
+      let depth = depth.clone();
+      close_requested_handlers().lock().unwrap().insert(
+        window_id,
+        Arc::new(move |event: CloseRequestedEvent| {
+          // A blocking handler (e.g. a modal confirm dialog) pumps OS
+          // events, which can deliver a second close-requested on this
+          // same thread. The trampoline must not hold the map lock across
+          // the handler invocation, or this recursion deadlocks.
+          if depth.fetch_add(1, Ordering::SeqCst) == 0 {
+            unsafe {
+              close_requested_trampoline(std::ptr::null_mut(), event.window_id)
+            };
+          }
+        }),
+      );
+    }
+
+    unsafe { close_requested_trampoline(std::ptr::null_mut(), window_id) };
+    assert_eq!(depth.load(Ordering::SeqCst), 2);
+
+    close_requested_handlers()
+      .lock()
+      .unwrap()
+      .remove(&window_id);
   }
 
   #[test]
@@ -755,7 +817,7 @@ mod tests {
       let seen_window_id = seen_window_id.clone();
       close_requested_handlers().lock().unwrap().insert(
         window_id,
-        Box::new(move |event: CloseRequestedEvent| {
+        Arc::new(move |event: CloseRequestedEvent| {
           calls.fetch_add(1, Ordering::SeqCst);
           seen_window_id.store(event.window_id, Ordering::SeqCst);
         }),
@@ -786,7 +848,7 @@ mod tests {
       let fired = fired.clone();
       close_requested_handlers().lock().unwrap().insert(
         registered_window_id,
-        Box::new(move |_event: CloseRequestedEvent| {
+        Arc::new(move |_event: CloseRequestedEvent| {
           fired.store(true, Ordering::SeqCst);
         }),
       );

--- a/capi/src/mouse.rs
+++ b/capi/src/mouse.rs
@@ -743,8 +743,8 @@ mod tests {
 
   #[test]
   fn close_requested_dispatches_to_registered_handler_once() {
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
 
     let window_id = 4242;
     let calls = Arc::new(AtomicU32::new(0));
@@ -775,8 +775,8 @@ mod tests {
 
   #[test]
   fn close_requested_only_fires_handler_for_matching_window_id() {
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
 
     let registered_window_id = 1;
     let other_window_id = 2;

--- a/capi/src/mouse.rs
+++ b/capi/src/mouse.rs
@@ -463,6 +463,8 @@ pub struct CloseRequestedEvent {
   pub window_id: u32,
 }
 
+// See `Window::on_close_requested` for the public contract; this just dispatches to
+// the registered handler for `window_id`, if any.
 unsafe extern "C" fn close_requested_trampoline(
   _user_data: *mut c_void,
   window_id: u32,
@@ -721,5 +723,83 @@ mod tests {
     };
     assert!(focused.focused);
     assert!(!blurred.focused);
+  }
+
+  // --- Close requested trampoline / handler map ---
+  //
+  // These call `close_requested_trampoline` directly rather than going
+  // through `on_close_requested`/`ensure_close_requested`, which call
+  // `crate::api()` and would panic without a real backend API table
+  // registered. The trampoline itself only touches the handler map, so it's
+  // testable in isolation.
+
+  #[test]
+  fn close_requested_no_handler_is_noop() {
+    // No handler registered for this window_id: dispatching must not panic
+    // and must not touch any other window's handler.
+    close_requested_handlers().lock().unwrap().clear();
+    unsafe { close_requested_trampoline(std::ptr::null_mut(), 9001) };
+  }
+
+  #[test]
+  fn close_requested_dispatches_to_registered_handler_once() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    let window_id = 4242;
+    let calls = Arc::new(AtomicU32::new(0));
+    let seen_window_id = Arc::new(AtomicU32::new(0));
+
+    {
+      let calls = calls.clone();
+      let seen_window_id = seen_window_id.clone();
+      close_requested_handlers().lock().unwrap().insert(
+        window_id,
+        Box::new(move |event: CloseRequestedEvent| {
+          calls.fetch_add(1, Ordering::SeqCst);
+          seen_window_id.store(event.window_id, Ordering::SeqCst);
+        }),
+      );
+    }
+
+    unsafe { close_requested_trampoline(std::ptr::null_mut(), window_id) };
+
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert_eq!(seen_window_id.load(Ordering::SeqCst), window_id);
+
+    close_requested_handlers()
+      .lock()
+      .unwrap()
+      .remove(&window_id);
+  }
+
+  #[test]
+  fn close_requested_only_fires_handler_for_matching_window_id() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let registered_window_id = 1;
+    let other_window_id = 2;
+    let fired = Arc::new(AtomicBool::new(false));
+
+    {
+      let fired = fired.clone();
+      close_requested_handlers().lock().unwrap().insert(
+        registered_window_id,
+        Box::new(move |_event: CloseRequestedEvent| {
+          fired.store(true, Ordering::SeqCst);
+        }),
+      );
+    }
+
+    unsafe {
+      close_requested_trampoline(std::ptr::null_mut(), other_window_id)
+    };
+    assert!(!fired.load(Ordering::SeqCst));
+
+    close_requested_handlers()
+      .lock()
+      .unwrap()
+      .remove(&registered_window_id);
   }
 }

--- a/cef/src/app.cc
+++ b/cef/src/app.cc
@@ -179,6 +179,18 @@ bool LaufeyHandler::OnBeforePopup(
 
 bool LaufeyHandler::DoClose(CefRefPtr<CefBrowser> browser) {
   CEF_REQUIRE_UI_THREAD();
+  auto* loader = RuntimeLoader::GetInstance();
+  uint32_t wid = loader->GetLaufeyIdForBrowser(browser);
+  bool proceed = (wid == 0) || loader->DispatchCloseRequestedEvent(wid);
+  if (!proceed) {
+    // A registered handler always defers: the app decides later, out of
+    // band, by calling close_window() -- which force-closes via
+    // CloseBrowser(true) and bypasses this negotiation entirely.
+    // is_closing_ is deliberately NOT set here so a later close attempt
+    // (e.g. Cmd+Q) runs this sequence fresh instead of silently no-op'ing
+    // (see IsClosing() in main_mac.mm).
+    return true;
+  }
   if (browser_list_.size() == 1) {
     is_closing_ = true;
   }
@@ -187,12 +199,6 @@ bool LaufeyHandler::DoClose(CefRefPtr<CefBrowser> browser) {
 
 void LaufeyHandler::OnBeforeClose(CefRefPtr<CefBrowser> browser) {
   CEF_REQUIRE_UI_THREAD();
-
-  auto* loader = RuntimeLoader::GetInstance();
-  uint32_t wid = loader->GetLaufeyIdForBrowser(browser);
-  if (wid > 0) {
-    loader->DispatchCloseRequestedEvent(wid);
-  }
 
   for (auto it = browser_list_.begin(); it != browser_list_.end(); ++it) {
     if ((*it)->IsSame(browser)) {
@@ -390,6 +396,13 @@ void LaufeyHandler::CloseAllBrowsers(bool force_close) {
     CefPostTask(TID_UI, base::BindOnce(&LaufeyHandler::CloseAllBrowsers, this,
                                        force_close));
     return;
+  }
+  // A forced close bypasses DoClose (see close_window's CloseBrowser(true)),
+  // so it never sets is_closing_ there. Set it here instead -- the only
+  // caller is terminate:'s app-quit path, which checks IsClosing() as a
+  // reentry guard against a second quit attempt.
+  if (force_close) {
+    is_closing_ = true;
   }
   for (const auto& browser : browser_list_) {
     browser->GetHost()->CloseBrowser(force_close);

--- a/cef/src/app.cc
+++ b/cef/src/app.cc
@@ -127,6 +127,21 @@ void LaufeyWindowDelegate::OnWindowDestroyed(CefRefPtr<CefWindow> window) {
 }
 
 bool LaufeyWindowDelegate::CanClose(CefRefPtr<CefWindow> window) {
+  // The close-requested negotiation lives here, not in DoClose: laufey's
+  // Views-hosted browsers run the default Chrome runtime style, and CEF
+  // only calls CefLifeSpanHandler::DoClose for Alloy-style browsers (see
+  // include/cef_life_span_handler.h) — a DoClose-based dispatch would
+  // simply never fire. CanClose runs for every close attempt on the
+  // CefWindow, user- and code-initiated alike; programmatic closes
+  // (close_window(), app quit) mark themselves close-allowed first so they
+  // skip the negotiation instead of re-deferring forever.
+  auto* loader = RuntimeLoader::GetInstance();
+  if (laufey_id_ > 0 && !loader->IsCloseAllowed(laufey_id_) &&
+      !loader->DispatchCloseRequestedEvent(laufey_id_)) {
+    // A registered handler defers the close: the app decides later, out of
+    // band, by calling close_window().
+    return false;
+  }
   CefRefPtr<CefBrowser> browser = browser_view_->GetBrowser();
   return browser ? browser->GetHost()->TryCloseBrowser() : true;
 }
@@ -179,18 +194,9 @@ bool LaufeyHandler::OnBeforePopup(
 
 bool LaufeyHandler::DoClose(CefRefPtr<CefBrowser> browser) {
   CEF_REQUIRE_UI_THREAD();
-  auto* loader = RuntimeLoader::GetInstance();
-  uint32_t wid = loader->GetLaufeyIdForBrowser(browser);
-  bool proceed = (wid == 0) || loader->DispatchCloseRequestedEvent(wid);
-  if (!proceed) {
-    // A registered handler always defers: the app decides later, out of
-    // band, by calling close_window() -- which force-closes via
-    // CloseBrowser(true) and bypasses this negotiation entirely.
-    // is_closing_ is deliberately NOT set here so a later close attempt
-    // (e.g. Cmd+Q) runs this sequence fresh instead of silently no-op'ing
-    // (see IsClosing() in main_mac.mm).
-    return true;
-  }
+  // No close-requested dispatch here: it lives in
+  // LaufeyWindowDelegate::CanClose, because Chrome-runtime-style browsers
+  // (laufey's default) never receive a DoClose call at all.
   if (browser_list_.size() == 1) {
     is_closing_ = true;
   }
@@ -397,12 +403,23 @@ void LaufeyHandler::CloseAllBrowsers(bool force_close) {
                                        force_close));
     return;
   }
-  // A forced close bypasses DoClose (see close_window's CloseBrowser(true)),
-  // so it never sets is_closing_ there. Set it here instead -- the only
-  // caller is terminate:'s app-quit path, which checks IsClosing() as a
-  // reentry guard against a second quit attempt.
+  // App-level quit: mark every window close-allowed so CanClose skips the
+  // close-requested negotiation -- quit is deliberately not interceptable
+  // by a window's on_close hook. Note CloseBrowser(force_close=true) only
+  // skips the beforeunload/unload prompt (see include/cef_browser.h); it
+  // does NOT bypass CanClose or DoClose, which is why the marks are needed.
+  // is_closing_ doubles as terminate:'s reentry guard against a second quit
+  // attempt while the closes are in flight; with the negotiation skipped
+  // the quit always completes, so latching it is safe.
+  auto* loader = RuntimeLoader::GetInstance();
   if (force_close) {
     is_closing_ = true;
+    for (const auto& browser : browser_list_) {
+      uint32_t wid = loader->GetLaufeyIdForBrowser(browser);
+      if (wid > 0) {
+        loader->MarkCloseAllowed(wid);
+      }
+    }
   }
   for (const auto& browser : browser_list_) {
     browser->GetHost()->CloseBrowser(force_close);

--- a/cef/src/main_mac.mm
+++ b/cef/src/main_mac.mm
@@ -53,10 +53,11 @@ void LaufeyOpenExternalURL(const std::string& url) {
 }
 
 - (void)terminate:(id)sender {
-  // Force-close (bypass DoClose/the close-requested hook) -- app-level quit
-  // (the "quit" menu role routes here) is intentionally not interceptable
-  // by a window's on_close hook, only the window's own close control is.
-  // Matches close_window()'s CloseBrowser(true), the same bypass path.
+  // Force-close: CloseAllBrowsers(true) marks every window close-allowed
+  // (so CanClose skips the close-requested negotiation) and skips the
+  // beforeunload prompt. App-level quit (the "quit" menu role routes here)
+  // is intentionally not interceptable by a window's on_close hook, only
+  // the window's own close control is.
   LaufeyHandler* handler = LaufeyHandler::GetInstance();
   if (handler && !handler->IsClosing()) {
     handler->CloseAllBrowsers(true);

--- a/cef/src/main_mac.mm
+++ b/cef/src/main_mac.mm
@@ -53,9 +53,13 @@ void LaufeyOpenExternalURL(const std::string& url) {
 }
 
 - (void)terminate:(id)sender {
+  // Force-close (bypass DoClose/the close-requested hook) -- app-level quit
+  // (the "quit" menu role routes here) is intentionally not interceptable
+  // by a window's on_close hook, only the window's own close control is.
+  // Matches close_window()'s CloseBrowser(true), the same bypass path.
   LaufeyHandler* handler = LaufeyHandler::GetInstance();
   if (handler && !handler->IsClosing()) {
-    handler->CloseAllBrowsers(false);
+    handler->CloseAllBrowsers(true);
   }
 }
 @end

--- a/cef/src/runtime_loader.cc
+++ b/cef/src/runtime_loader.cc
@@ -1392,6 +1392,20 @@ static void Backend_SetCloseRequestedHandler(void* data,
   loader->SetCloseRequestedHandler(handler, user_data);
 }
 
+// Test hook (API >= 31): synthesize a close-requested event through the same
+// dispatch path a real OS close click uses (see DoClose in app.cc). Returns
+// true if the window is still open afterward (a registered handler
+// deferred the close).
+static bool Backend_TestTriggerCloseRequested(void* data, uint32_t window_id) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  bool proceed = loader->DispatchCloseRequestedEvent(window_id);
+  if (proceed) {
+    Backend_CloseWindow(data, window_id);
+    return false;
+  }
+  return true;
+}
+
 static int Backend_ShowDialog(void* /*data*/, uint32_t /*window_id*/,
                               int dialog_type, const char* title,
                               const char* message, const char* default_value,
@@ -1518,6 +1532,7 @@ void RuntimeLoader::InitializeBackendApi() {
   backend_api_.set_resize_handler = Backend_SetResizeHandler;
   backend_api_.set_move_handler = Backend_SetMoveHandler;
   backend_api_.set_close_requested_handler = Backend_SetCloseRequestedHandler;
+  backend_api_.test_trigger_close_requested = Backend_TestTriggerCloseRequested;
 
   backend_api_.poll_js_calls = [](void* data) {
     RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);

--- a/cef/src/runtime_loader.cc
+++ b/cef/src/runtime_loader.cc
@@ -1377,6 +1377,12 @@ static void Backend_CloseWindow(void* data, uint32_t window_id) {
   auto* loader = RuntimeLoader::GetInstance();
   CefRefPtr<CefBrowser> browser = loader->GetBrowserForWindow(window_id);
   if (browser) {
+    // Mark before closing: CloseBrowser eventually drives the CefWindow's
+    // close, whose CanClose must skip the close-requested negotiation for a
+    // programmatic close (force_close=true only skips the beforeunload
+    // prompt, not CanClose -- without the mark a registered handler would
+    // re-defer this close forever).
+    loader->MarkCloseAllowed(window_id);
     CefPostTask(TID_UI, base::BindOnce(
                             [](CefRefPtr<CefBrowser> b) {
                               b->GetHost()->CloseBrowser(true);
@@ -1393,9 +1399,9 @@ static void Backend_SetCloseRequestedHandler(void* data,
 }
 
 // Test hook (API >= 31): synthesize a close-requested event through the same
-// dispatch path a real OS close click uses (see DoClose in app.cc). Returns
-// true if the window is still open afterward (a registered handler
-// deferred the close).
+// dispatch code a real OS close click runs (see CanClose in app.cc). Returns
+// true if a registered handler deferred the close; false means the close was
+// initiated (it completes asynchronously via CloseBrowser).
 static bool Backend_TestTriggerCloseRequested(void* data, uint32_t window_id) {
   RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
   bool proceed = loader->DispatchCloseRequestedEvent(window_id);

--- a/cef/src/runtime_loader.h
+++ b/cef/src/runtime_loader.h
@@ -302,11 +302,17 @@ class RuntimeLoader {
     close_requested_user_data_ = user_data;
   }
 
-  void DispatchCloseRequestedEvent(uint32_t window_id) {
+  // Returns true if the caller should proceed to actually close. A
+  // registered handler always defers the close (API >= 31): the app
+  // decides later, out of band, by calling close_window. No handler means
+  // proceed, unchanged from backends predating API 31.
+  bool DispatchCloseRequestedEvent(uint32_t window_id) {
     std::lock_guard<std::mutex> lock(close_requested_mutex_);
     if (close_requested_handler_) {
       close_requested_handler_(close_requested_user_data_, window_id);
+      return false;
     }
+    return true;
   }
 
   // --- Custom URL scheme handler (API >= 26) ---

--- a/cef/src/runtime_loader.h
+++ b/cef/src/runtime_loader.h
@@ -57,11 +57,27 @@ class RuntimeLoader {
 
   void UnregisterBrowser(uint32_t window_id) {
     std::lock_guard<std::mutex> lock(windows_mutex_);
+    close_allowed_.erase(window_id);
     auto it = browsers_.find(window_id);
     if (it != browsers_.end()) {
       browser_id_to_laufey_id_.erase(it->second->GetIdentifier());
       browsers_.erase(it);
     }
+  }
+
+  // Programmatic closes (close_window(), app quit) mark the window
+  // close-allowed before closing it, so LaufeyWindowDelegate::CanClose
+  // skips the close-requested negotiation for it: a programmatic close IS
+  // the resolution of that negotiation (or an app-level quit, which is
+  // deliberately not interceptable). Cleared in UnregisterBrowser.
+  void MarkCloseAllowed(uint32_t window_id) {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    close_allowed_.insert(window_id);
+  }
+
+  bool IsCloseAllowed(uint32_t window_id) {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    return close_allowed_.count(window_id) > 0;
   }
 
   CefRefPtr<CefBrowser> GetBrowserForWindow(uint32_t window_id) {
@@ -307,9 +323,19 @@ class RuntimeLoader {
   // decides later, out of band, by calling close_window. No handler means
   // proceed, unchanged from backends predating API 31.
   bool DispatchCloseRequestedEvent(uint32_t window_id) {
-    std::lock_guard<std::mutex> lock(close_requested_mutex_);
-    if (close_requested_handler_) {
-      close_requested_handler_(close_requested_user_data_, window_id);
+    // Copy the handler out and release the mutex before invoking it: the
+    // handler may block (e.g. a modal confirm dialog) and pump OS events,
+    // which can re-enter this dispatch on the same thread — with a
+    // non-recursive mutex still held, that would self-deadlock.
+    laufey_close_requested_fn handler;
+    void* user_data;
+    {
+      std::lock_guard<std::mutex> lock(close_requested_mutex_);
+      handler = close_requested_handler_;
+      user_data = close_requested_user_data_;
+    }
+    if (handler) {
+      handler(user_data, window_id);
       return false;
     }
     return true;
@@ -372,6 +398,9 @@ class RuntimeLoader {
   std::atomic<bool> running_{false};
 
   std::map<uint32_t, CefRefPtr<CefBrowser>> browsers_;
+  // Windows being closed programmatically; CanClose skips the
+  // close-requested negotiation for them (see MarkCloseAllowed).
+  std::set<uint32_t> close_allowed_;
   std::map<int, uint32_t>
       browser_id_to_laufey_id_;  // CefBrowser::GetIdentifier() -> laufey_id
   std::map<uint64_t, uint32_t>

--- a/docs/c-abi.md
+++ b/docs/c-abi.md
@@ -150,64 +150,76 @@ back to a socket transport.
 ## Close-requested handler defers the close (API ≥ 31)
 
 As of API 31, registering `set_close_requested_handler` changes the backend's
-behavior: the window no longer closes on its own when the user clicks the
-close button. Resolving is just a call to the existing `close_window` — no
-new handle type, no synchronous return value. This isn't only a veto — it's
-a general hold point for whatever needs to happen before the window
-actually goes away: flush writes, close file handles, wait for a save to
-finish, ask the user, or just always let it through once cleanup is done.
+behavior: the window no longer closes on its own when the user clicks the close
+button. Resolving is just a call to the existing `close_window` — no new handle
+type, no synchronous return value. This isn't only a veto — it's a general hold
+point for whatever needs to happen before the window actually goes away: flush
+writes, close file handles, wait for a save to finish, ask the user, or just
+always let it through once cleanup is done.
 
 1. The runtime calls `set_close_requested_handler(handler, user_data)`.
-2. When the user requests a close, the backend invokes `handler` and then
-   does nothing further — the window stays open.
-3. The runtime does whatever work it needs, then decides — synchronously
-   inside `handler` or later from any thread: call `close_window(window_id)`
-   to actually close it, or do nothing to leave it open. There's no separate
+2. When the user requests a close, the backend invokes `handler` and then does
+   nothing further — the window stays open.
+3. The runtime does whatever work it needs, then decides — synchronously inside
+   `handler` or later from any thread: call `close_window(window_id)` to
+   actually close it, or do nothing to leave it open. There's no separate
    "resolve" call and no opaque handle to release — `close_window` already
    bypasses each backend's close-confirm gate (`[NSWindow close]` not
    `performClose:`, `DestroyWindow` not `WM_CLOSE`, `gtk_widget_destroy` not
-   `gtk_window_close`, CEF's `CloseBrowser(true)` force-close), so it's safe
+   `gtk_window_close`, CEF marks the window close-allowed so `CanClose` skips
+   the negotiation before force-closing with `CloseBrowser(true)`), so it's safe
    to call from inside the handler without re-entering it.
 
-With no handler registered, behavior is unchanged from backends predating
-API 31: the window closes immediately on click.
+With no handler registered, behavior is unchanged from backends predating API
+31: the window closes immediately on click.
 
-**Scope: only the window's own close control.** `handler` fires for the
-window's native close affordance — the title bar close button, `Alt+F4`, a
-window manager's "close" action — and nothing else. It does **not** fire for
-`Cmd+Q`, an app menu or tray "Quit" item, or any other app-level termination
-path, on any backend. This is deliberate, not an oversight: a window that
-hides itself instead of closing (e.g. a tray-icon app — see
-[window-events.md](window-events.md)) needs an app-level quit that it
-*can't* intercept, or "Quit" would just re-hide the window instead of
-exiting. Concretely:
+**The defer is process-wide, not per-window.** Once registered, the handler
+receives — and holds open — _every_ window's close click, including windows the
+embedder never meant to intercept. A handler that only cares about some windows
+must call `close_window(window_id)` itself for the rest, or those windows become
+unclosable. Higher-level per-window APIs (e.g. the Rust capi's
+`Window::on_close_requested`) implement this exact pattern: their process-wide C
+handler completes the close for any window without a registered per-window
+handler.
 
-- macOS: CEF explicitly force-closes (`CloseBrowser(true)`, bypassing
-  `DoClose`) from its `terminate:` override, which is what both the `"quit"`
-  menu role and `Cmd+Q`'s default handling route through — see
-  `cef/src/main_mac.mm`. WebView never wires `applicationShouldTerminate:` to
+**Scope: only the window's own close control.** `handler` fires for the window's
+native close affordance — the title bar close button, `Alt+F4`, a window
+manager's "close" action — and nothing else. It does **not** fire for `Cmd+Q`,
+an app menu or tray "Quit" item, or any other app-level termination path, on any
+backend. This is deliberate, not an oversight: a window that hides itself
+instead of closing (e.g. a tray-icon app — see
+[window-events.md](window-events.md)) needs an app-level quit that it _can't_
+intercept, or "Quit" would just re-hide the window instead of exiting.
+Concretely:
+
+- macOS: CEF's `terminate:` override — which is what both the `"quit"` menu role
+  and `Cmd+Q`'s default handling route through — marks every window
+  close-allowed (so `CanClose` skips the close-requested negotiation) and
+  force-closes with `CloseBrowser(true)`, which skips the beforeunload prompt
+  (it does _not_ bypass `CanClose`/`DoClose`; the close-allowed marks are what
+  skip the negotiation) — see `cef/src/main_mac.mm` and `CloseAllBrowsers` in
+  `cef/src/app.cc`. WebView never wires `applicationShouldTerminate:` to
   `windowShouldClose:` at all, so it's already outside the handler's reach.
-- Windows and Linux: the `"quit"` menu role has no automatic OS-level
-  binding on either platform — clicking it just invokes the runtime's own
-  registered menu-click callback (`menu_linux.cc`; unhandled on Windows,
-  where `"quit"` isn't special-cased at all), so it never touches the close
-  path unless the runtime's own callback explicitly calls `close_window`.
+- Windows and Linux: the `"quit"` menu role has no automatic OS-level binding on
+  either platform — clicking it just invokes the runtime's own registered
+  menu-click callback (`menu_linux.cc`; unhandled on Windows, where `"quit"`
+  isn't special-cased at all), so it never touches the close path unless the
+  runtime's own callback explicitly calls `close_window`.
 
 If a runtime wants "are you sure you want to quit?" behavior, it needs an
 app-level quit hook — which doesn't exist yet in this ABI — not
 `set_close_requested_handler`.
 
-`handler` fires synchronously on the backend's native UI thread (e.g.
-AppKit's `windowShouldClose:`) — the same thread every other event handler
+`handler` fires synchronously on the backend's native UI thread (e.g. AppKit's
+`windowShouldClose:`) — the same thread every other event handler
 (`set_resize_handler`, `set_mouse_click_handler`, etc.) already fires on. A
-*synchronous* confirm dialog can be shown directly in the handler (the
-backend's `show_dialog` pumps OS events while blocking, so this doesn't
-deadlock). Runtimes that want to resolve asynchronously instead need their
-own way back into their async runtime from that thread; e.g. the Rust
-`laufey` crate's `Window::on_close_requested` docs recommend capturing a
-`tokio::runtime::Handle` ahead of time rather than relying on a bare
-`tokio::spawn`, which requires an ambient runtime context this thread
-doesn't have.
+_synchronous_ confirm dialog can be shown directly in the handler (the backend's
+`show_dialog` pumps OS events while blocking, so this doesn't deadlock).
+Runtimes that want to resolve asynchronously instead need their own way back
+into their async runtime from that thread; e.g. the Rust `laufey` crate's
+`Window::on_close_requested` docs recommend capturing a `tokio::runtime::Handle`
+ahead of time rather than relying on a bare `tokio::spawn`, which requires an
+ambient runtime context this thread doesn't have.
 
 ## Threading
 

--- a/docs/c-abi.md
+++ b/docs/c-abi.md
@@ -6,7 +6,7 @@ It defines the boundary between a **backend** (a native executable embedding a
 browser engine) and a **runtime** (a shared library holding the application
 logic). The backend implements the ABI; the runtime consumes it.
 
-`LAUFEY_API_VERSION` (currently `28`) versions the contract. The `version` field
+`LAUFEY_API_VERSION` (currently `31`) versions the contract. The `version` field
 on the API table lets a runtime detect the backend's vintage and avoid calling
 function pointers a backend predates (older backends leave new pointers `NULL`).
 
@@ -56,7 +56,8 @@ The pointers group into:
 - **Event handlers** — `set_keyboard_event_handler`, `set_mouse_click_handler`,
   `set_mouse_move_handler`, `set_wheel_handler`,
   `set_cursor_enter_leave_handler`, `set_focused_handler`, `set_resize_handler`,
-  `set_move_handler`, `set_close_requested_handler`.
+  `set_move_handler`, `set_close_requested_handler` (defer-until-close_window
+  contract as of API ≥ 31 — see below).
 - **Window handles** — `get_window_handle`, `get_display_handle`,
   `get_window_handle_type` (for GPU surface creation).
 - **Menus** — `set_application_menu`, `show_context_menu`, `open_devtools`.
@@ -145,6 +146,68 @@ finishes, `scheme_response_write` / `scheme_request_read_body` return negative;
 the runtime should stop and call `scheme_response_finish`. Backends predating
 API version 26 leave these pointers `NULL`; the runtime must null-check and fall
 back to a socket transport.
+
+## Close-requested handler defers the close (API ≥ 31)
+
+As of API 31, registering `set_close_requested_handler` changes the backend's
+behavior: the window no longer closes on its own when the user clicks the
+close button. Resolving is just a call to the existing `close_window` — no
+new handle type, no synchronous return value. This isn't only a veto — it's
+a general hold point for whatever needs to happen before the window
+actually goes away: flush writes, close file handles, wait for a save to
+finish, ask the user, or just always let it through once cleanup is done.
+
+1. The runtime calls `set_close_requested_handler(handler, user_data)`.
+2. When the user requests a close, the backend invokes `handler` and then
+   does nothing further — the window stays open.
+3. The runtime does whatever work it needs, then decides — synchronously
+   inside `handler` or later from any thread: call `close_window(window_id)`
+   to actually close it, or do nothing to leave it open. There's no separate
+   "resolve" call and no opaque handle to release — `close_window` already
+   bypasses each backend's close-confirm gate (`[NSWindow close]` not
+   `performClose:`, `DestroyWindow` not `WM_CLOSE`, `gtk_widget_destroy` not
+   `gtk_window_close`, CEF's `CloseBrowser(true)` force-close), so it's safe
+   to call from inside the handler without re-entering it.
+
+With no handler registered, behavior is unchanged from backends predating
+API 31: the window closes immediately on click.
+
+**Scope: only the window's own close control.** `handler` fires for the
+window's native close affordance — the title bar close button, `Alt+F4`, a
+window manager's "close" action — and nothing else. It does **not** fire for
+`Cmd+Q`, an app menu or tray "Quit" item, or any other app-level termination
+path, on any backend. This is deliberate, not an oversight: a window that
+hides itself instead of closing (e.g. a tray-icon app — see
+[window-events.md](window-events.md)) needs an app-level quit that it
+*can't* intercept, or "Quit" would just re-hide the window instead of
+exiting. Concretely:
+
+- macOS: CEF explicitly force-closes (`CloseBrowser(true)`, bypassing
+  `DoClose`) from its `terminate:` override, which is what both the `"quit"`
+  menu role and `Cmd+Q`'s default handling route through — see
+  `cef/src/main_mac.mm`. WebView never wires `applicationShouldTerminate:` to
+  `windowShouldClose:` at all, so it's already outside the handler's reach.
+- Windows and Linux: the `"quit"` menu role has no automatic OS-level
+  binding on either platform — clicking it just invokes the runtime's own
+  registered menu-click callback (`menu_linux.cc`; unhandled on Windows,
+  where `"quit"` isn't special-cased at all), so it never touches the close
+  path unless the runtime's own callback explicitly calls `close_window`.
+
+If a runtime wants "are you sure you want to quit?" behavior, it needs an
+app-level quit hook — which doesn't exist yet in this ABI — not
+`set_close_requested_handler`.
+
+`handler` fires synchronously on the backend's native UI thread (e.g.
+AppKit's `windowShouldClose:`) — the same thread every other event handler
+(`set_resize_handler`, `set_mouse_click_handler`, etc.) already fires on. A
+*synchronous* confirm dialog can be shown directly in the handler (the
+backend's `show_dialog` pumps OS events while blocking, so this doesn't
+deadlock). Runtimes that want to resolve asynchronously instead need their
+own way back into their async runtime from that thread; e.g. the Rust
+`laufey` crate's `Window::on_close_requested` docs recommend capturing a
+`tokio::runtime::Handle` ahead of time rather than relying on a bare
+`tokio::spawn`, which requires an ambient runtime context this thread
+doesn't have.
 
 ## Threading
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -24,7 +24,12 @@ matrix over the C ABI surface, and a phased rollout.
 > by CEF/WebView. The macOS self-accessibility approach (`§7.2`) is verified
 > standalone but not yet embedded (it needs the backend's main thread — see
 > `§8`). Implementing the hook exposed and fixed a pre-existing self-deadlock in
-> the Winit menu-callback registration.
+> the Winit menu-callback registration. The `test_trigger_close_requested`
+> hook (API 31, `§8`) for `set_close_requested_handler`'s
+> defer-until-close_window contract is implemented for all backends and
+> verified green under Winit and WebView on macOS; it rides the same
+> pre-existing CI exclusions above for CEF and the Windows/Linux webview
+> combos, so those aren't gated by it yet.
 
 ---
 
@@ -363,6 +368,39 @@ Doing this surfaced and fixed a pre-existing self-deadlock in Winit:
 submenus (std `Mutex` is not reentrant), freezing the main thread on any menu
 containing a submenu.
 
+**Implemented (API 31):**
+
+```c
+// Synthesizes a close-requested event on window_id through the same
+// dispatch path a real OS close click uses. Returns true if the window is
+// still open afterward (a registered set_close_requested_handler deferred
+// the close), false if it closed immediately (no handler was registered).
+bool (*test_trigger_close_requested)(void* backend_data, uint32_t window_id);
+```
+
+Implemented for both native-chrome codebases, reusing each backend's existing
+close dispatch rather than a new registry (unlike the click hook, there's
+nothing to "look up by id" — a window has at most one pending close):
+
+- **Winit** (`backend-winit-common`): dispatches via the same
+  `dispatch_close_requested_event`, then queues the same
+  `CommonEvent::CloseWindow` `close_window` uses if the dispatch says to
+  proceed.
+- **CEF + WebView** (each backend's `RuntimeLoader`): dispatches via
+  `DispatchCloseRequestedEvent`, then calls `CloseWindow`/`Backend_CloseWindow`
+  directly if it says to proceed.
+
+The capi exposes `laufey::test_trigger_close_requested(window_id)`. The
+`native_e2e` runtime registers an `on_close_requested` handler that *stashes* the
+window_id instead of resolving inline, calls the hook to confirm the window
+stays open, then closes it from outside the handler and confirms it
+actually closes — proving resolution genuinely works from outside the
+handler (not just that a bool threads through) round-trips.
+Verified green under Winit and WebView on macOS; CEF and the Windows/Linux
+webview backends implement the same plumbing but ride the pre-existing
+`native-e2e` CI exclusions for those combos (`§` status note above) — not
+gated by this change, but not covered by CI for it either.
+
 **Not yet added** (future hooks, same append-and-`N/A` pattern):
 
 ```c
@@ -390,6 +428,7 @@ per-OS (`Linux/macOS/Windows`); WebView's web-layer cells differ by engine.
 | -------------------------------------- | --------- | --- | ------- | ---------------- | ---------------------- |
 | Window geometry/state/opacity readback | A         | ✅  | ✅      | ✅ (Rust)        | ✅                     |
 | Window lifecycle events                | B         | ✅  | ✅      | ✅               | ✅                     |
+| Close handler (defer-until-close)      | B (`§8`)  | ✅ (Linux/Win nightly-only) | ✅ (Linux nightly-only) | ✅ | ✅ (macOS; see `§8`) |
 | Clipboard round-trip                   | A         | ✅  | ✅      | ✅               | ✅                     |
 | Window handles / types                 | A         | ✅  | ✅      | ✅               | ✅                     |
 | Application / context menu             | D + B     | ✅  | ✅      | ✅ (`muda`)      | ✅                     |

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -24,12 +24,11 @@ matrix over the C ABI surface, and a phased rollout.
 > by CEF/WebView. The macOS self-accessibility approach (`§7.2`) is verified
 > standalone but not yet embedded (it needs the backend's main thread — see
 > `§8`). Implementing the hook exposed and fixed a pre-existing self-deadlock in
-> the Winit menu-callback registration. The `test_trigger_close_requested`
-> hook (API 31, `§8`) for `set_close_requested_handler`'s
-> defer-until-close_window contract is implemented for all backends and
-> verified green under Winit and WebView on macOS; it rides the same
-> pre-existing CI exclusions above for CEF and the Windows/Linux webview
-> combos, so those aren't gated by it yet.
+> the Winit menu-callback registration. The `test_trigger_close_requested` hook
+> (API 31, `§8`) for `set_close_requested_handler`'s defer-until-close_window
+> contract is implemented for all backends and verified green under Winit and
+> WebView on macOS; it rides the same pre-existing CI exclusions above for CEF
+> and the Windows/Linux webview combos, so those aren't gated by it yet.
 
 ---
 
@@ -372,9 +371,13 @@ containing a submenu.
 
 ```c
 // Synthesizes a close-requested event on window_id through the same
-// dispatch path a real OS close click uses. Returns true if the window is
-// still open afterward (a registered set_close_requested_handler deferred
-// the close), false if it closed immediately (no handler was registered).
+// dispatch code a real OS close click runs. Returns true if a registered
+// set_close_requested_handler deferred the close (the window is still
+// open), false if the close proceeded (no handler was registered).
+// "Proceeded" means initiated: winit and CEF queue the actual close, so
+// poll window state instead of asserting right after a false return. The
+// handler runs synchronously on the calling thread, not the backend UI
+// thread a real close click would use.
 bool (*test_trigger_close_requested)(void* backend_data, uint32_t window_id);
 ```
 
@@ -383,23 +386,21 @@ close dispatch rather than a new registry (unlike the click hook, there's
 nothing to "look up by id" — a window has at most one pending close):
 
 - **Winit** (`backend-winit-common`): dispatches via the same
-  `dispatch_close_requested_event`, then queues the same
-  `CommonEvent::CloseWindow` `close_window` uses if the dispatch says to
-  proceed.
+  `dispatch_close_requested_event`, then proceeds through `backend_close_window`
+  — the real close entry point.
 - **CEF + WebView** (each backend's `RuntimeLoader`): dispatches via
-  `DispatchCloseRequestedEvent`, then calls `CloseWindow`/`Backend_CloseWindow`
-  directly if it says to proceed.
+  `DispatchCloseRequestedEvent`, then proceeds through `Backend_CloseWindow`.
 
 The capi exposes `laufey::test_trigger_close_requested(window_id)`. The
-`native_e2e` runtime registers an `on_close_requested` handler that *stashes* the
-window_id instead of resolving inline, calls the hook to confirm the window
-stays open, then closes it from outside the handler and confirms it
-actually closes — proving resolution genuinely works from outside the
-handler (not just that a bool threads through) round-trips.
-Verified green under Winit and WebView on macOS; CEF and the Windows/Linux
-webview backends implement the same plumbing but ride the pre-existing
-`native-e2e` CI exclusions for those combos (`§` status note above) — not
-gated by this change, but not covered by CI for it either.
+`native_e2e` runtime registers an `on_close_requested` handler that _stashes_
+the window_id instead of resolving inline, calls the hook to confirm the window
+stays open, then closes it from outside the handler and confirms it actually
+closes — proving resolution genuinely works from outside the handler (not just
+that a bool threads through) round-trips. Verified green under Winit and WebView
+on macOS; CEF and the Windows/Linux webview backends implement the same plumbing
+but ride the pre-existing `native-e2e` CI exclusions for those combos (`§`
+status note above) — not gated by this change, but not covered by CI for it
+either.
 
 **Not yet added** (future hooks, same append-and-`N/A` pattern):
 
@@ -424,22 +425,22 @@ above only touches an in-process mutex and works from any thread.
 Rows are capability groups; each cell is per-backend. Every ✅ is additionally
 per-OS (`Linux/macOS/Windows`); WebView's web-layer cells differ by engine.
 
-| Capability                             | Technique | CEF | WebView | Winit            | Gate                   |
-| -------------------------------------- | --------- | --- | ------- | ---------------- | ---------------------- |
-| Window geometry/state/opacity readback | A         | ✅  | ✅      | ✅ (Rust)        | ✅                     |
-| Window lifecycle events                | B         | ✅  | ✅      | ✅               | ✅                     |
-| Close handler (defer-until-close)      | B (`§8`)  | ✅ (Linux/Win nightly-only) | ✅ (Linux nightly-only) | ✅ | ✅ (macOS; see `§8`) |
-| Clipboard round-trip                   | A         | ✅  | ✅      | ✅               | ✅                     |
-| Window handles / types                 | A         | ✅  | ✅      | ✅               | ✅                     |
-| Application / context menu             | D + B     | ✅  | ✅      | ✅ (`muda`)      | ✅                     |
-| Tray icon / menu / click               | D + B     | ✅  | ✅      | ✅ (`tray-icon`) | ✅ (win tray nightly)  |
-| Notifications payload                  | D         | ✅  | ✅      | probe            | Linux ✅, else nightly |
-| Dock / taskbar                         | A/D/F     | ✅  | ✅      | probe            | partial                |
-| Raw mouse/keyboard/wheel events        | E         | ✅  | ✅      | ✅               | ✅ (with hook)         |
-| Web: bindings/execute_js/navigate/load | B/C/E     | ✅  | ✅      | **N/A**          | ✅ (CEF/WebView)       |
-| Custom scheme handlers                 | C         | ✅  | ✅      | **N/A**          | ✅ (CEF/WebView)       |
-| DevTools                               | F         | ✅  | partial | N/A              | nightly                |
-| Dialogs (alert/confirm/prompt/file)    | F         | ⚠️  | ⚠️      | ⚠️               | nightly                |
+| Capability                             | Technique | CEF                         | WebView                 | Winit            | Gate                   |
+| -------------------------------------- | --------- | --------------------------- | ----------------------- | ---------------- | ---------------------- |
+| Window geometry/state/opacity readback | A         | ✅                          | ✅                      | ✅ (Rust)        | ✅                     |
+| Window lifecycle events                | B         | ✅                          | ✅                      | ✅               | ✅                     |
+| Close handler (defer-until-close)      | B (`§8`)  | ✅ (Linux/Win nightly-only) | ✅ (Linux nightly-only) | ✅               | ✅ (macOS; see `§8`)   |
+| Clipboard round-trip                   | A         | ✅                          | ✅                      | ✅               | ✅                     |
+| Window handles / types                 | A         | ✅                          | ✅                      | ✅               | ✅                     |
+| Application / context menu             | D + B     | ✅                          | ✅                      | ✅ (`muda`)      | ✅                     |
+| Tray icon / menu / click               | D + B     | ✅                          | ✅                      | ✅ (`tray-icon`) | ✅ (win tray nightly)  |
+| Notifications payload                  | D         | ✅                          | ✅                      | probe            | Linux ✅, else nightly |
+| Dock / taskbar                         | A/D/F     | ✅                          | ✅                      | probe            | partial                |
+| Raw mouse/keyboard/wheel events        | E         | ✅                          | ✅                      | ✅               | ✅ (with hook)         |
+| Web: bindings/execute_js/navigate/load | B/C/E     | ✅                          | ✅                      | **N/A**          | ✅ (CEF/WebView)       |
+| Custom scheme handlers                 | C         | ✅                          | ✅                      | **N/A**          | ✅ (CEF/WebView)       |
+| DevTools                               | F         | ✅                          | partial                 | N/A              | nightly                |
+| Dialogs (alert/confirm/prompt/file)    | F         | ⚠️                          | ⚠️                      | ⚠️               | nightly                |
 
 Net: ~90% of the C ABI is a hosted-CI PR gate across all backends; only modal /
 outward-facing surfaces are nightly.

--- a/docs/window-events.md
+++ b/docs/window-events.md
@@ -16,14 +16,13 @@ let win = Window::new(800, 600)
   .load("index.html");
 ```
 
-`on_close_requested` fires when the user clicks the window's own close
-control (title bar button, `Alt+F4`, a window manager's close action) —
-never for `Cmd+Q`, a "Quit" menu/tray item, or any other app-level
-termination. Registering it holds the window open: it won't close on its
-own until you call `Window::close()`, synchronously in the handler or later
-from any thread, e.g. after a confirm dialog or once unsaved work is
-flushed. Doing nothing leaves it open — which is also how you'd implement
-"hide to tray" instead of closing:
+`on_close_requested` fires when the user clicks the window's own close control
+(title bar button, `Alt+F4`, a window manager's close action) — never for
+`Cmd+Q`, a "Quit" menu/tray item, or any other app-level termination.
+Registering it holds the window open: it won't close on its own until you call
+`Window::close()`, synchronously in the handler or later from any thread, e.g.
+after a confirm dialog or once unsaved work is flushed. Doing nothing leaves it
+open — which is also how you'd implement "hide to tray" instead of closing:
 
 ```rust
 .on_close_requested(|event| {
@@ -31,8 +30,8 @@ flushed. Doing nothing leaves it open — which is also how you'd implement
 })
 ```
 
-Or, for a synchronous confirm dialog, call `Window::confirm()` directly in
-the handler — it blocks (pumping OS events) until the user answers:
+Or, for a synchronous confirm dialog, call `Window::confirm()` directly in the
+handler — it blocks (pumping OS events) until the user answers:
 
 ```rust
 .on_close_requested(|event| {
@@ -43,7 +42,7 @@ the handler — it blocks (pumping OS events) until the user answers:
 })
 ```
 
-See [c-abi.md](c-abi.md), "Close-requested handler defers the close", for
-the full contract, including why app-level quit paths are deliberately out
-of scope, and `examples/confirm_before_quit` for a complete runnable
-version of the confirm-dialog pattern above.
+See [c-abi.md](c-abi.md), "Close-requested handler defers the close", for the
+full contract, including why app-level quit paths are deliberately out of scope,
+and `examples/confirm_before_quit` for a complete runnable version of the
+confirm-dialog pattern above.

--- a/docs/window-events.md
+++ b/docs/window-events.md
@@ -6,13 +6,44 @@ between runs or to intervene before the window goes away.
 
 ```rust
 let win = Window::new(800, 600)
-  .on_focused(|focused| println!("focused: {focused}"))
-  .on_resize(|w, h| println!("resized {w}x{h}"))
-  .on_move(|x, y| println!("moved {x},{y}"))
-  .on_close_requested(|| println!("user clicked close"))
+  .on_focused(|event| println!("focused: {}", event.focused))
+  .on_resize(|event| println!("resized {}x{}", event.width, event.height))
+  .on_move(|event| println!("moved {},{}", event.x, event.y))
+  .on_close_requested(|event| {
+    println!("user clicked close on window {}", event.window_id);
+    Window::from_id(event.window_id).close();
+  })
   .load("index.html");
 ```
 
-The close-requested handler fires when the user clicks the window's close
-button, before the window is destroyed. This gives the runtime a chance to ask
-for confirmation or save unsaved work first.
+`on_close_requested` fires when the user clicks the window's own close
+control (title bar button, `Alt+F4`, a window manager's close action) —
+never for `Cmd+Q`, a "Quit" menu/tray item, or any other app-level
+termination. Registering it holds the window open: it won't close on its
+own until you call `Window::close()`, synchronously in the handler or later
+from any thread, e.g. after a confirm dialog or once unsaved work is
+flushed. Doing nothing leaves it open — which is also how you'd implement
+"hide to tray" instead of closing:
+
+```rust
+.on_close_requested(|event| {
+  Window::from_id(event.window_id).hide();
+})
+```
+
+Or, for a synchronous confirm dialog, call `Window::confirm()` directly in
+the handler — it blocks (pumping OS events) until the user answers:
+
+```rust
+.on_close_requested(|event| {
+  let win = Window::from_id(event.window_id);
+  if win.confirm("Quit?", "You have unsaved changes. Quit anyway?") {
+    win.close();
+  }
+})
+```
+
+See [c-abi.md](c-abi.md), "Close-requested handler defers the close", for
+the full contract, including why app-level quit paths are deliberately out
+of scope, and `examples/confirm_before_quit` for a complete runnable
+version of the confirm-dialog pattern above.

--- a/examples/confirm_before_quit/Cargo.toml
+++ b/examples/confirm_before_quit/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "confirm_before_quit_runtime"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+laufey = { path = "../../capi" }
+tokio = { version = "1", features = ["rt-multi-thread", "time", "macros"] }

--- a/examples/confirm_before_quit/src/lib.rs
+++ b/examples/confirm_before_quit/src/lib.rs
@@ -1,0 +1,92 @@
+//! Demonstrates `on_close_requested`: hold the window open until the user
+//! confirms, only when there's actually something to lose.
+//!
+//! The page can mark itself "dirty" (e.g. after the user types something)
+//! via the `markDirty`/`markClean` bindings. Clicking the window's close
+//! button then either closes immediately (nothing unsaved) or blocks on a
+//! native confirm dialog first.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use laufey::{Value, Window};
+
+fn confirm_before_quit_main() {
+  let rt = tokio::runtime::Runtime::new().unwrap();
+  rt.block_on(async {
+    let dirty = Arc::new(AtomicBool::new(false));
+
+    let mark_dirty = dirty.clone();
+    let mark_clean = dirty.clone();
+
+    let _win = Window::new(700, 400)
+      .title("Confirm Before Quit")
+      .bind("markDirty", move |call| {
+        mark_dirty.store(true, Ordering::SeqCst);
+        call.resolve(Value::Null);
+      })
+      .bind("markClean", move |call| {
+        mark_clean.store(false, Ordering::SeqCst);
+        call.resolve(Value::Null);
+      })
+      .on_close_requested(move |event| {
+        let win = Window::from_id(event.window_id);
+        if !dirty.load(Ordering::SeqCst) {
+          // Nothing unsaved -- close right away, same as not registering
+          // a hook at all.
+          win.close();
+          return;
+        }
+        // `confirm` blocks the handler (pumping OS events so other
+        // windows stay responsive) until the user answers. For a custom
+        // in-page confirm UI instead of this native dialog, resolve
+        // asynchronously: capture a `tokio::runtime::Handle` before this
+        // closure and call `handle.spawn(...)` here instead -- see
+        // docs/window-events.md.
+        if win.confirm(
+          "Quit without saving?",
+          "You have unsaved changes. Quit anyway?",
+        ) {
+          win.close();
+        }
+        // Otherwise: do nothing. The window stays open.
+      })
+      .load(
+        r#"data:text/html,<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Confirm Before Quit</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; margin: 2rem; }
+    textarea { width: 100%; height: 8rem; }
+    #status { margin-top: 0.5rem; color: #666; }
+  </style>
+</head>
+<body>
+  <h1>Confirm Before Quit</h1>
+  <p>Type something below, then click the window's close button.</p>
+  <textarea id="notes" placeholder="Unsaved notes..."></textarea>
+  <div id="status">No unsaved changes</div>
+  <script>
+    const notes = document.getElementById("notes");
+    const status = document.getElementById("status");
+    notes.addEventListener("input", () => {
+      if (notes.value.length > 0) {
+        Laufey.markDirty();
+        status.textContent = "Unsaved changes -- closing will ask for confirmation";
+      } else {
+        Laufey.markClean();
+        status.textContent = "No unsaved changes";
+      }
+    });
+  </script>
+</body>
+</html>"#,
+      );
+
+    laufey::run().await;
+  });
+}
+
+laufey::main!(confirm_before_quit_main);

--- a/examples/native_e2e/src/lib.rs
+++ b/examples/native_e2e/src/lib.rs
@@ -359,7 +359,9 @@ fn e2e_main() {
     // window_id instead of resolving inline — proving resolution genuinely
     // works from outside the handler (any thread, any time), not just
     // synchronously inline. Synthesizes the close via
-    // test_trigger_close_requested (API >= 31); N/A on backends without it.
+    // test_trigger_close_requested (API >= 31, implemented by every in-tree
+    // backend — init_api's version check guarantees it's present, so a
+    // failure here is a regression, never a missing hook).
     let close_win = Window::new(200, 150)
       .title("native-e2e-close")
       .load("data:text/html,<!doctype html><title>close</title>");
@@ -388,9 +390,20 @@ fn e2e_main() {
 
     let still_open_after_defer =
       laufey::test_trigger_close_requested(close_win_id);
-    if !baseline_sized || !close_handler_fired.load(Ordering::SeqCst) {
-      na("close handler (backend has no test_trigger_close_requested hook, API < 31)");
+    if !baseline_sized {
+      // Precondition, not a close-dispatch check: without a sized baseline
+      // the stays-open/closed probes below are meaningless.
+      na("close handler (precondition failed: close_win never reported a nonzero size)");
     } else {
+      // The hook itself is guaranteed present: init_api rejects any backend
+      // whose API version differs from 31, and every in-tree backend
+      // implements test_trigger_close_requested. Dispatch is synchronous,
+      // so a handler that didn't fire is a real regression — fail, don't
+      // N/A.
+      check(
+        "on_close_requested handler fired for synthesized close",
+        close_handler_fired.load(Ordering::SeqCst),
+      );
       check(
         "close handler defers — window stays open",
         still_open_after_defer,

--- a/examples/native_e2e/src/lib.rs
+++ b/examples/native_e2e/src/lib.rs
@@ -10,9 +10,11 @@
 //!   [e2e] FAIL <name>   supported here but wrong  -> process exits 1
 //!   [e2e] N/A  <name>   capability absent on this backend (not a failure)
 //!
-//! This covers Layer 0 (in-process readback + event-callback round-trips) and
+//! This covers Layer 0 (in-process readback + event-callback round-trips),
 //! menu/tray *click* round-trips via the `test_click_menu_item` C ABI hook
-//! (API 30+; `N/A` on backends without it). OS-observer *structure* checks
+//! (API 30+; `N/A` on backends without it), and the close-handler round-trip
+//! via `test_trigger_close_requested` (API 31+; `N/A` on backends without
+//! it). OS-observer *structure* checks
 //! (Layer 1: the Linux D-Bus driver; macOS/Windows pending a backend hook)
 //! live outside this runtime. See docs/e2e-testing.md.
 //!
@@ -350,6 +352,72 @@ fn e2e_main() {
     // (a dispatch_sync to the main queue deadlocks against the backend event
     // loop). It belongs behind a backend test hook; tracked as a follow-up.
     na("menu/tray OS-structure check (Linux: D-Bus driver; macOS/Windows: pending backend hook)");
+
+    // ---- close-requested handler round-trip --------------------------------
+    // A second window (kept separate from `win`, which must survive to
+    // shutdown). Registers an on_close_requested handler that *stashes* the
+    // window_id instead of resolving inline — proving resolution genuinely
+    // works from outside the handler (any thread, any time), not just
+    // synchronously inline. Synthesizes the close via
+    // test_trigger_close_requested (API >= 31); N/A on backends without it.
+    let close_win = Window::new(200, 150)
+      .title("native-e2e-close")
+      .load("data:text/html,<!doctype html><title>close</title>");
+    let close_win_id = close_win.id();
+    let baseline_sized = wait_for(
+      || {
+        let (w, _h) = close_win.get_size();
+        w != 0
+      },
+      50,
+      40,
+    )
+    .await;
+
+    let close_handler_fired = Arc::new(AtomicBool::new(false));
+    let pending_close: Arc<std::sync::Mutex<Option<u32>>> =
+      Arc::new(std::sync::Mutex::new(None));
+    let close_win = {
+      let fired = close_handler_fired.clone();
+      let pending = pending_close.clone();
+      close_win.on_close_requested(move |event| {
+        fired.store(true, Ordering::SeqCst);
+        *pending.lock().unwrap() = Some(event.window_id);
+      })
+    };
+
+    let still_open_after_defer =
+      laufey::test_trigger_close_requested(close_win_id);
+    if !baseline_sized || !close_handler_fired.load(Ordering::SeqCst) {
+      na("close handler (backend has no test_trigger_close_requested hook, API < 31)");
+    } else {
+      check(
+        "close handler defers — window stays open",
+        still_open_after_defer,
+      );
+      let (w, _h) = close_win.get_size();
+      check("window state still readable after deferred close", w != 0);
+
+      // Resolve the stashed window_id — from here, not from inside the
+      // handler — and confirm the window actually closes.
+      let pending_id = pending_close.lock().unwrap().take();
+      if let Some(id) = pending_id {
+        Window::from_id(id).close();
+      }
+      let closed = wait_for(
+        || {
+          let (w, h) = close_win.get_size();
+          w == 0 && h == 0
+        },
+        50,
+        40,
+      )
+      .await;
+      check(
+        "closing from outside the on_close_requested handler actually closes the window",
+        closed,
+      );
+    }
 
     // ---- Layer-1 hold ----------------------------------------------------
     // When driven by the D-Bus observer (native_e2e_driver), stay alive with

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -493,6 +493,21 @@ static void Backend_SetCloseRequestedHandler(void* data,
   loader->SetCloseRequestedHandler(handler, user_data);
 }
 
+// Test hook (API >= 31): synthesize a close-requested event through the same
+// dispatch path a real OS close click uses. Returns true if the window is
+// still open afterward (a registered handler deferred the close).
+static bool Backend_TestTriggerCloseRequested(void* data, uint32_t window_id) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  bool proceed = loader->DispatchCloseRequestedEvent(window_id);
+  if (proceed) {
+    if (LaufeyBackend* backend = loader->GetBackend()) {
+      backend->CloseWindow(window_id);
+    }
+    return false;
+  }
+  return true;
+}
+
 static void Backend_SetPageLoadHandler(void* data, laufey_page_load_fn handler,
                                        void* user_data) {
   RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
@@ -755,6 +770,7 @@ void RuntimeLoader::InitializeBackendApi() {
   backend_api_.create_window_ex = Backend_CreateWindowEx;
   backend_api_.close_window = Backend_CloseWindow;
   backend_api_.set_close_requested_handler = Backend_SetCloseRequestedHandler;
+  backend_api_.test_trigger_close_requested = Backend_TestTriggerCloseRequested;
   backend_api_.set_page_load_handler = Backend_SetPageLoadHandler;
   backend_api_.show_dialog = Backend_ShowDialog;
   backend_api_.string_free = Backend_StringFree;

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -494,15 +494,16 @@ static void Backend_SetCloseRequestedHandler(void* data,
 }
 
 // Test hook (API >= 31): synthesize a close-requested event through the same
-// dispatch path a real OS close click uses. Returns true if the window is
-// still open afterward (a registered handler deferred the close).
+// dispatch code a real OS close click runs. Returns true if a registered
+// handler deferred the close; false means the close proceeded. Proceeds
+// through Backend_CloseWindow — the real close entry point — rather than
+// re-inlining its body, so the hook can't silently diverge from the
+// shipping close path.
 static bool Backend_TestTriggerCloseRequested(void* data, uint32_t window_id) {
   RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
   bool proceed = loader->DispatchCloseRequestedEvent(window_id);
   if (proceed) {
-    if (LaufeyBackend* backend = loader->GetBackend()) {
-      backend->CloseWindow(window_id);
-    }
+    Backend_CloseWindow(data, window_id);
     return false;
   }
   return true;

--- a/webview/src/runtime_loader.h
+++ b/webview/src/runtime_loader.h
@@ -231,9 +231,19 @@ class RuntimeLoader {
   // decides later, out of band, by calling close_window. No handler means
   // proceed, unchanged from backends predating API 31.
   bool DispatchCloseRequestedEvent(uint32_t window_id) {
-    std::lock_guard<std::mutex> lock(close_requested_mutex_);
-    if (close_requested_handler_) {
-      close_requested_handler_(close_requested_user_data_, window_id);
+    // Copy the handler out and release the mutex before invoking it: the
+    // handler may block (e.g. a modal confirm dialog) and pump OS events,
+    // which can re-enter this dispatch on the same thread — with a
+    // non-recursive mutex still held, that would self-deadlock.
+    laufey_close_requested_fn handler;
+    void* user_data;
+    {
+      std::lock_guard<std::mutex> lock(close_requested_mutex_);
+      handler = close_requested_handler_;
+      user_data = close_requested_user_data_;
+    }
+    if (handler) {
+      handler(user_data, window_id);
       return false;
     }
     return true;

--- a/webview/src/runtime_loader.h
+++ b/webview/src/runtime_loader.h
@@ -226,11 +226,17 @@ class RuntimeLoader {
     close_requested_user_data_ = user_data;
   }
 
-  void DispatchCloseRequestedEvent(uint32_t window_id) {
+  // Returns true if the caller should proceed to actually close the window.
+  // A registered handler always defers the close (API >= 31): the app
+  // decides later, out of band, by calling close_window. No handler means
+  // proceed, unchanged from backends predating API 31.
+  bool DispatchCloseRequestedEvent(uint32_t window_id) {
     std::lock_guard<std::mutex> lock(close_requested_mutex_);
     if (close_requested_handler_) {
       close_requested_handler_(close_requested_user_data_, window_id);
+      return false;
     }
+    return true;
   }
 
   void SetPageLoadHandler(laufey_page_load_fn handler, void* user_data) {

--- a/webview/src/webview_linux.cc
+++ b/webview/src/webview_linux.cc
@@ -463,10 +463,12 @@ static void on_script_message(WebKitUserContentManager* manager,
   }
 }
 
+// "destroy" fires only after the widget is already being torn down -- too
+// late to veto anything, so it's just final cleanup. The close-requested
+// dispatch (and any veto) happens earlier, from "delete-event" below.
 static void on_window_destroy(GtkWidget* widget, gpointer user_data) {
   uint32_t wid = LaufeyIdForWidget(widget);
   if (wid > 0) {
-    RuntimeLoader::GetInstance()->DispatchCloseRequestedEvent(wid);
     UnregisterWidget(widget);
   }
   // If no more windows, quit
@@ -476,6 +478,23 @@ static void on_window_destroy(GtkWidget* widget, gpointer user_data) {
       gtk_main_quit();
     }
   }
+}
+
+// "delete-event" fires when the user requests a close (e.g. clicks the
+// titlebar close button) and, unlike "destroy", can veto it: returning TRUE
+// blocks GTK's default handler from calling gtk_widget_destroy. A registered
+// handler always defers (returns TRUE here); no handler falls through to
+// the unchanged default flow (proceeds to destroy, which fires
+// on_window_destroy above).
+static gboolean on_window_delete_event(GtkWidget* widget, GdkEvent* event,
+                                       gpointer user_data) {
+  uint32_t wid = LaufeyIdForWidget(widget);
+  if (wid == 0) {
+    return FALSE;
+  }
+  bool proceed =
+      RuntimeLoader::GetInstance()->DispatchCloseRequestedEvent(wid);
+  return proceed ? FALSE : TRUE;
 }
 
 WebKitGTKBackend::WebKitGTKBackend() {
@@ -672,6 +691,8 @@ void WebKitGTKBackend::CreateWindowEx(uint32_t window_id, int width, int height,
     }
     gtk_window_set_default_size(GTK_WINDOW(window), width, height);
     g_signal_connect(window, "destroy", G_CALLBACK(on_window_destroy), nullptr);
+    g_signal_connect(window, "delete-event",
+                     G_CALLBACK(on_window_delete_event), nullptr);
     g_signal_connect(window, "key-press-event", G_CALLBACK(on_key_event),
                      nullptr);
     g_signal_connect(window, "key-release-event", G_CALLBACK(on_key_event),

--- a/webview/src/webview_linux.cc
+++ b/webview/src/webview_linux.cc
@@ -492,8 +492,7 @@ static gboolean on_window_delete_event(GtkWidget* widget, GdkEvent* event,
   if (wid == 0) {
     return FALSE;
   }
-  bool proceed =
-      RuntimeLoader::GetInstance()->DispatchCloseRequestedEvent(wid);
+  bool proceed = RuntimeLoader::GetInstance()->DispatchCloseRequestedEvent(wid);
   return proceed ? FALSE : TRUE;
 }
 
@@ -691,8 +690,8 @@ void WebKitGTKBackend::CreateWindowEx(uint32_t window_id, int width, int height,
     }
     gtk_window_set_default_size(GTK_WINDOW(window), width, height);
     g_signal_connect(window, "destroy", G_CALLBACK(on_window_destroy), nullptr);
-    g_signal_connect(window, "delete-event",
-                     G_CALLBACK(on_window_delete_event), nullptr);
+    g_signal_connect(window, "delete-event", G_CALLBACK(on_window_delete_event),
+                     nullptr);
     g_signal_connect(window, "key-press-event", G_CALLBACK(on_key_event),
                      nullptr);
     g_signal_connect(window, "key-release-event", G_CALLBACK(on_key_event),

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -145,6 +145,12 @@ class WKWebViewBackend : public LaufeyBackend {
   void HandleJsMessage(uint32_t window_id, uint64_t call_id,
                        const std::string& method, laufey::ValuePtr args);
 
+  // Called from the window delegate's windowWillClose: when AppKit closes
+  // the NSWindow directly (windowShouldClose: returned YES because no
+  // close-requested handler deferred). CloseWindow() never reaches this —
+  // it detaches the delegate (via RemoveWindowState) before [window close].
+  void OnWindowClosedByUser(uint32_t window_id);
+
  private:
   MacWindowState* GetWindow(uint32_t window_id);
   void RemoveWindowState(uint32_t window_id);
@@ -467,6 +473,7 @@ class MacSchemeExchange : public SchemeExchangeBase {
 @end
 
 @interface LaufeyWindowDelegate : NSObject <NSWindowDelegate>
+@property(nonatomic, assign) WKWebViewBackend* backend;
 @property(nonatomic, assign) uint32_t windowId;
 @end
 
@@ -477,6 +484,19 @@ class MacSchemeExchange : public SchemeExchangeBase {
              self.windowId)
              ? YES
              : NO;
+}
+
+// Fires only for AppKit-driven closes (windowShouldClose: returned YES):
+// without it the backend's per-window state — the NSWindow strong ref
+// (releasedWhenClosed:NO), notification observers, and the "laufey" script
+// message handler — would leak, and the window id would stay live (get_size
+// still reporting the old frame, show() able to resurrect the window).
+// CloseWindow() detaches the delegate before [window close], so the
+// programmatic path can't double-clean through here.
+- (void)windowWillClose:(NSNotification*)notification {
+  if (self.backend) {
+    self.backend->OnWindowClosedByUser(self.windowId);
+  }
 }
 
 @end
@@ -565,6 +585,11 @@ WKWebViewBackend::~WKWebViewBackend() {
       if (state.webview)
         [state.webview.configuration.userContentController
             removeScriptMessageHandlerForName:@"laufey"];
+      // Detach the delegate: AppKit may keep an on-screen window alive past
+      // this destructor, and its windowWillClose: would otherwise call back
+      // into this destroyed backend.
+      if (state.window)
+        [state.window setDelegate:nil];
       UnregisterNSWindow(state.window);
     }
   }
@@ -601,6 +626,13 @@ void WKWebViewBackend::RemoveWindowState(uint32_t window_id) {
     UnregisterNSWindow(state.window);
   }
   windows_.erase(it);
+}
+
+void WKWebViewBackend::OnWindowClosedByUser(uint32_t window_id) {
+  // Main thread (AppKit delivers windowWillClose: there); safe to take the
+  // lock and tear down state while the window finishes closing.
+  std::lock_guard<std::mutex> lock(windows_mutex_);
+  RemoveWindowState(window_id);
 }
 
 void WKWebViewBackend::InstallGlobalMonitors() {
@@ -855,6 +887,7 @@ void WKWebViewBackend::CreateWindowEx(uint32_t window_id, int width, int height,
       [window center];
 
       LaufeyWindowDelegate* delegate = [[LaufeyWindowDelegate alloc] init];
+      delegate.backend = this;
       delegate.windowId = window_id;
       [window setDelegate:delegate];
 

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -473,8 +473,10 @@ class MacSchemeExchange : public SchemeExchangeBase {
 @implementation LaufeyWindowDelegate
 
 - (BOOL)windowShouldClose:(NSWindow*)sender {
-  RuntimeLoader::GetInstance()->DispatchCloseRequestedEvent(self.windowId);
-  return NO;
+  return RuntimeLoader::GetInstance()->DispatchCloseRequestedEvent(
+             self.windowId)
+             ? YES
+             : NO;
 }
 
 @end

--- a/webview/src/webview_windows.cc
+++ b/webview/src/webview_windows.cc
@@ -554,9 +554,15 @@ LRESULT CALLBACK WebView2Backend::WindowProc(HWND hwnd, UINT msg, WPARAM wParam,
           false);
       break;
     }
-    case WM_CLOSE:
+    case WM_CLOSE: {
+      bool proceed = true;
       if (wid > 0) {
-        RuntimeLoader::GetInstance()->DispatchCloseRequestedEvent(wid);
+        proceed = RuntimeLoader::GetInstance()->DispatchCloseRequestedEvent(wid);
+      }
+      if (!proceed) {
+        // A close-requested handler deferred the close: leave the window open.
+        // Not calling DestroyWindow is the standard Win32 idiom for this.
+        return 0;
       }
       // Check if any windows remain
       {
@@ -569,6 +575,7 @@ LRESULT CALLBACK WebView2Backend::WindowProc(HWND hwnd, UINT msg, WPARAM wParam,
       }
       DestroyWindow(hwnd);
       return 0;
+    }
     case WM_COMMAND:
       if (win32_menu::HandleMenuCommand(hwnd, wParam))
         return 0;

--- a/webview/src/webview_windows.cc
+++ b/webview/src/webview_windows.cc
@@ -557,22 +557,17 @@ LRESULT CALLBACK WebView2Backend::WindowProc(HWND hwnd, UINT msg, WPARAM wParam,
     case WM_CLOSE: {
       bool proceed = true;
       if (wid > 0) {
-        proceed = RuntimeLoader::GetInstance()->DispatchCloseRequestedEvent(wid);
+        proceed =
+            RuntimeLoader::GetInstance()->DispatchCloseRequestedEvent(wid);
       }
       if (!proceed) {
         // A close-requested handler deferred the close: leave the window open.
         // Not calling DestroyWindow is the standard Win32 idiom for this.
         return 0;
       }
-      // Check if any windows remain
-      {
-        std::lock_guard<std::recursive_mutex> lock(g_hwnd_mutex);
-        // Remove this window from map
-        g_hwnd_to_laufey_id.erase(hwnd);
-        if (g_hwnd_to_laufey_id.empty()) {
-          PostQuitMessage(0);
-        }
-      }
+      // Unregistration and the last-window quit check live in WM_DESTROY,
+      // which every destroy path hits (this one, and CloseWindow's direct
+      // DestroyWindow when a deferred close is later resolved).
       DestroyWindow(hwnd);
       return 0;
     }
@@ -580,8 +575,17 @@ LRESULT CALLBACK WebView2Backend::WindowProc(HWND hwnd, UINT msg, WPARAM wParam,
       if (win32_menu::HandleMenuCommand(hwnd, wParam))
         return 0;
       break;
-    case WM_DESTROY:
+    case WM_DESTROY: {
+      // Single exit point for window teardown: fires for WM_CLOSE-initiated
+      // closes and for CloseWindow()'s direct DestroyWindow alike, so a
+      // deferred close resolved via close_window still quits the message
+      // loop when the last window goes away.
+      std::lock_guard<std::recursive_mutex> lock(g_hwnd_mutex);
+      if (g_hwnd_to_laufey_id.erase(hwnd) > 0 && g_hwnd_to_laufey_id.empty()) {
+        PostQuitMessage(0);
+      }
       return 0;
+    }
     case WM_UI_TASK: {
       UiTaskData* taskData = reinterpret_cast<UiTaskData*>(lParam);
       if (taskData) {
@@ -1010,10 +1014,9 @@ void WebView2Backend::CloseWindow(uint32_t window_id) {
   if (state) {
     if (state->controller)
       state->controller->Close();
-    {
-      std::lock_guard<std::recursive_mutex> hlock(g_hwnd_mutex);
-      g_hwnd_to_laufey_id.erase(state->hwnd);
-    }
+    // Deliberately not erased from g_hwnd_to_laufey_id here: WM_DESTROY
+    // (sent synchronously by DestroyWindow) owns unregistration and the
+    // last-window quit check, for this path and the WM_CLOSE path alike.
     DestroyWindow(state->hwnd);
     windows_.erase(window_id);
   }

--- a/winit/src/main.rs
+++ b/winit/src/main.rs
@@ -267,10 +267,11 @@ impl ApplicationHandler<UserEvent> for App {
 
     match event {
       WindowEvent::CloseRequested => {
-        let proceed = laufey_backend_winit_common::dispatch_close_requested_event(
-          &state.common.handlers,
-          laufey_id,
-        );
+        let proceed =
+          laufey_backend_winit_common::dispatch_close_requested_event(
+            &state.common.handlers,
+            laufey_id,
+          );
         if proceed {
           self.close_window(laufey_id);
           if self.windows.is_empty() {

--- a/winit/src/main.rs
+++ b/winit/src/main.rs
@@ -267,13 +267,15 @@ impl ApplicationHandler<UserEvent> for App {
 
     match event {
       WindowEvent::CloseRequested => {
-        laufey_backend_winit_common::dispatch_close_requested_event(
+        let proceed = laufey_backend_winit_common::dispatch_close_requested_event(
           &state.common.handlers,
           laufey_id,
         );
-        self.close_window(laufey_id);
-        if self.windows.is_empty() {
-          event_loop.exit();
+        if proceed {
+          self.close_window(laufey_id);
+          if self.windows.is_empty() {
+            event_loop.exit();
+          }
         }
       }
       WindowEvent::Resized(PhysicalSize { width, height }) => {


### PR DESCRIPTION
## Summary

- Add `Window::on_close`: registering it holds the window open when the user clicks its close control. Call `Window::close()` explicity to actually close it; doing nothing leaves it open.
- Deliberately scoped to the window's own close control only. Never Cmd+Q, menu/tray "Quit", or other app-level termination, so hide-to-tray apps aren't broken by Quit re-hiding instead of exiting. Fixed CEF's `"quit"` menu role, which was violating this.
- Implemented across all five backends (winit, WebView ×3, CEF).
- New example: `examples/confirm_before_quit`.
- Docs: `docs/c-abi.md`, `docs/window-events.md`.

## Test plan

- [x] `cargo test -p laufey --lib` / `--doc`
- [x] `native-e2e` round-trip green on winit + WebView (macOS)
- [x] Manual click-through smoke tests on macOS, incl. `confirm_before_quit`
- [ ] CEF not locally buildable here, relies on CI
- [ ] WebView/Linux not in the `native-e2e` CI matrix (pre-existing gap). Needs a manual check on real Linux before wide release