### PR TITLE
feat: add on_open_url hook for OS-routed deep links (macOS)

### DIFF
--- a/backend-common/CMakeLists.txt
+++ b/backend-common/CMakeLists.txt
@@ -47,6 +47,7 @@ if(APPLE)
     src/permissions_mac.mm
     src/keymap_mac.mm
     src/dock_mac.mm
+    src/open_url_mac.mm
     src/menu_mac.mm
     src/tray_mac.mm
   )

--- a/backend-common/include/laufey_backend_common.h
+++ b/backend-common/include/laufey_backend_common.h
@@ -319,6 +319,27 @@ void SetDockReopenHandlerMac(laufey_dock_reopen_fn handler, void* user_data);
 void FireDockReopenMac(bool has_visible_windows);
 
 // ---------------------------------------------------------------------------
+// Deep links / custom URL schemes (macOS)
+// ---------------------------------------------------------------------------
+//
+// Stores the open-url handler set by Backend_SetOpenUrlHandler_Mac /
+// WKWebViewBackend::SetOpenUrlHandler. Each backend's AppDelegate calls
+// FireOpenUrlMac() once per URL from application:openURLs:.
+//
+// A launch URL always arrives before the runtime (loaded on a worker thread)
+// can register anything, so FireOpenUrlMac buffers up to
+// LAUFEY_MAX_PENDING_OPEN_URLS URLs while no handler is set and
+// SetOpenUrlHandlerMac flushes them, in order, on registration. Passing a
+// null handler clears it and re-arms buffering.
+void SetOpenUrlHandlerMac(laufey_open_url_fn handler, void* user_data);
+void FireOpenUrlMac(const char* url);
+
+// Test-only. Backs the C ABI `test_trigger_open_url` hook: routes `url`
+// through FireOpenUrlMac and reports whether a handler consumed it (true) or
+// it was buffered for a later registration (false).
+bool TestTriggerOpenUrlMac(const char* url);
+
+// ---------------------------------------------------------------------------
 // NSMenu builder (macOS)
 // ---------------------------------------------------------------------------
 //

--- a/backend-common/src/open_url_mac.mm
+++ b/backend-common/src/open_url_mac.mm
@@ -1,0 +1,102 @@
+// Copyright 2025 Divy Srivastava. All rights reserved. MIT license.
+//
+// Deep-link (custom URL scheme) plumbing shared by the CEF and WebView
+// backends on macOS. Each backend's AppDelegate implements
+// `application:openURLs:` and calls FireOpenUrlMac() once per URL; the
+// storage and the cold-start buffer live here so both delegates behave
+// identically. See docs/deep-links.md.
+
+#include "laufey_backend_common.h"
+
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace laufey_common {
+
+namespace {
+
+std::mutex& OpenUrlMutex() {
+  static std::mutex m;
+  return m;
+}
+
+laufey_open_url_fn g_open_url_fn = nullptr;
+void* g_open_url_data = nullptr;
+
+// URLs delivered before a handler was registered. A cold-start deep link is
+// always in this position: AppKit dispatches the Apple Event as soon as the
+// app finishes launching, while the runtime that registers the handler is
+// still coming up on its own thread.
+std::vector<std::string>& PendingOpenUrls() {
+  static std::vector<std::string> v;
+  return v;
+}
+
+}  // namespace
+
+void SetOpenUrlHandlerMac(laufey_open_url_fn handler, void* user_data) {
+  std::vector<std::string> pending;
+  {
+    std::lock_guard<std::mutex> lock(OpenUrlMutex());
+    g_open_url_fn = handler;
+    g_open_url_data = user_data;
+    // Clearing the handler re-arms buffering; anything still queued stays
+    // queued for the next registration.
+    if (handler) {
+      pending = std::move(PendingOpenUrls());
+      PendingOpenUrls().clear();
+    }
+  }
+
+  // Outside the lock: the handler may re-enter (e.g. clear itself), and it is
+  // embedder code we don't want to run under our own mutex. Note this runs on
+  // the registering thread, not the UI thread — the only case where an
+  // open-url callback fires anywhere else.
+  for (const std::string& url : pending) {
+    handler(user_data, url.c_str());
+  }
+}
+
+void FireOpenUrlMac(const char* url) {
+  if (!url) {
+    return;
+  }
+
+  laufey_open_url_fn fn = nullptr;
+  void* data = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(OpenUrlMutex());
+    fn = g_open_url_fn;
+    data = g_open_url_data;
+    if (!fn) {
+      std::vector<std::string>& pending = PendingOpenUrls();
+      // Drop the oldest rather than the newest: the most recent link is the
+      // one the user is waiting on.
+      if (pending.size() >= LAUFEY_MAX_PENDING_OPEN_URLS) {
+        pending.erase(pending.begin());
+      }
+      pending.emplace_back(url);
+    }
+  }
+
+  if (fn) {
+    fn(data, url);
+  }
+}
+
+bool TestTriggerOpenUrlMac(const char* url) {
+  if (!url) {
+    return false;
+  }
+  bool delivered;
+  {
+    std::lock_guard<std::mutex> lock(OpenUrlMutex());
+    delivered = g_open_url_fn != nullptr;
+  }
+  FireOpenUrlMac(url);
+  return delivered;
+}
+
+}  // namespace laufey_common

--- a/backend-winit-common/Cargo.toml
+++ b/backend-winit-common/Cargo.toml
@@ -17,7 +17,7 @@ notify-rust = "4"
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSAppearance", "NSDockTile", "NSMenu", "NSMenuItem", "NSResponder", "NSRunningApplication"] }
-objc2-foundation = { version = "0.3", features = ["NSString", "NSThread", "NSBundle", "NSError"] }
+objc2-foundation = { version = "0.3", features = ["NSString", "NSThread", "NSBundle", "NSError", "NSArray", "NSURL"] }
 objc2-user-notifications = "0.3"
 block2 = "0.6"
 dispatch2 = "0.3"

--- a/backend-winit-common/src/lib.rs
+++ b/backend-winit-common/src/lib.rs
@@ -4,6 +4,7 @@ pub use winit;
 
 pub mod dock;
 pub mod notification;
+pub mod open_url;
 pub mod permission;
 pub mod tray;
 
@@ -33,7 +34,7 @@ use winit::window::{Window, WindowLevel};
 // Bumping this in lockstep with the capi is mandatory: the capi's `init_api`
 // rejects any backend whose reported `version` differs, and the vtable layout
 // below must match the `laufey_backend_api` struct as of this version.
-pub const LAUFEY_API_VERSION: u32 = 34;
+pub const LAUFEY_API_VERSION: u32 = 35;
 
 /// Creation-time window style flags (mirror `LAUFEY_WINDOW_FLAG_*` in laufey.h).
 pub const LAUFEY_WINDOW_FLAG_FRAMELESS: u32 = 1 << 0;
@@ -564,6 +565,23 @@ pub struct LaufeyBackendApi {
     Option<unsafe extern "C" fn(*mut c_void, u32, bool)>,
   pub is_click_passthrough_forward:
     Option<unsafe extern "C" fn(*mut c_void, u32) -> bool>,
+
+  // --- Deep links / custom URL schemes (API >= 35) ---
+  // macOS only (a runtime-added `application:openURLs:` on winit's delegate —
+  // see open_url.rs). Both pointers stay None on Windows/Linux, where the OS
+  // hands the URL to a new process as argv and only the embedder can act on
+  // it. The fields MUST still be declared to keep the struct layout in sync
+  // with the `laufey_backend_api` the capi reads through the backend's
+  // pointer.
+  pub set_open_url_handler: Option<
+    unsafe extern "C" fn(
+      *mut c_void,
+      Option<open_url::LaufeyOpenUrlFn>,
+      *mut c_void,
+    ),
+  >,
+  pub test_trigger_open_url:
+    Option<unsafe extern "C" fn(*mut c_void, *const c_char) -> bool>,
 }
 
 unsafe impl Send for LaufeyBackendApi {}
@@ -1206,6 +1224,9 @@ pub fn create_api_base() -> LaufeyBackendApi {
     // observation API.
     set_click_passthrough_forward: None,
     is_click_passthrough_forward: None,
+    // Deep links (API >= 35): filled by fill_common_api on macOS only.
+    set_open_url_handler: None,
+    test_trigger_open_url: None,
   }
 }
 
@@ -2526,6 +2547,29 @@ macro_rules! define_common_backend_fns {
       $crate::dispatch_menu_click_by_id(&id)
     }
 
+    #[cfg(target_os = "macos")]
+    unsafe extern "C" fn backend_set_open_url_handler(
+      _data: *mut ::std::ffi::c_void,
+      handler: Option<$crate::open_url::LaufeyOpenUrlFn>,
+      user_data: *mut ::std::ffi::c_void,
+    ) {
+      $crate::open_url::set_handler(handler.map(|h| (h, user_data as usize)));
+    }
+
+    #[cfg(target_os = "macos")]
+    unsafe extern "C" fn backend_test_trigger_open_url(
+      _data: *mut ::std::ffi::c_void,
+      url: *const ::std::ffi::c_char,
+    ) -> bool {
+      if url.is_null() {
+        return false;
+      }
+      let url = unsafe { ::std::ffi::CStr::from_ptr(url) }
+        .to_string_lossy()
+        .into_owned();
+      $crate::open_url::test_trigger(&url)
+    }
+
     unsafe extern "C" fn backend_set_application_menu(
       _data: *mut ::std::ffi::c_void,
       window_id: u32,
@@ -2960,6 +3004,14 @@ macro_rules! fill_common_api {
     $api.test_click_menu_item = Some(backend_test_click_menu_item);
     $api.test_trigger_close_requested =
       Some(backend_test_trigger_close_requested);
+    // Deep links are macOS-only (see open_url.rs). Leaving the pointers None
+    // elsewhere lets an embedder detect the absence instead of registering a
+    // handler that silently never fires.
+    #[cfg(target_os = "macos")]
+    {
+      $api.set_open_url_handler = Some(backend_set_open_url_handler);
+      $api.test_trigger_open_url = Some(backend_test_trigger_open_url);
+    }
   };
 }
 
@@ -3846,6 +3898,12 @@ pub fn find_runtime_library() -> Option<PathBuf> {
 }
 
 pub fn load_and_start_runtime(api: LaufeyBackendApi) {
+  // Install `application:openURLs:` before the runtime comes up: AppKit only
+  // routes a launch URL to a delegate that already responds to the selector,
+  // and the runtime that registers the handler starts on the thread below.
+  #[cfg(target_os = "macos")]
+  open_url::install_delegate_methods();
+
   let runtime_path = find_runtime_library();
   match runtime_path {
     Some(path) => {

--- a/backend-winit-common/src/open_url.rs
+++ b/backend-winit-common/src/open_url.rs
@@ -1,0 +1,187 @@
+// Copyright 2025 Divy Srivastava. All rights reserved. MIT license.
+
+//! Deep links (custom URL schemes) for winit-based backends.
+//!
+//! macOS only, matching the C ABI contract in `capi/include/laufey.h`: AppKit
+//! delivers `acme://…` to the *running* app as an Apple Event, so one process
+//! handles every link. Windows and Linux instead spawn a new process with the
+//! URL in argv, which only the embedder that owns packaging can turn into
+//! "focus the running app" — those platforms leave the ABI pointers NULL.
+//!
+//! The delivery point is a runtime-added `application:openURLs:` on winit's
+//! `NSApplicationDelegate` subclass, the same technique `dock.rs` uses for
+//! `applicationDockMenu:`. Because the runtime is loaded on a worker thread
+//! (see `load_and_start_runtime`), a launch URL always arrives before any
+//! handler is registered, so URLs are buffered until one is.
+
+use std::ffi::{c_char, c_void, CString};
+use std::sync::Mutex;
+
+pub type LaufeyOpenUrlFn = unsafe extern "C" fn(*mut c_void, *const c_char);
+
+/// Mirrors `LAUFEY_MAX_PENDING_OPEN_URLS` in `capi/include/laufey.h`.
+const MAX_PENDING: usize = 16;
+
+static HANDLER: Mutex<Option<(LaufeyOpenUrlFn, usize)>> = Mutex::new(None);
+static PENDING: Mutex<Vec<CString>> = Mutex::new(Vec::new());
+
+/// Add `application:openURLs:` to winit's `NSApplicationDelegate` subclass.
+/// Idempotent. Call as early as possible — AppKit only routes a launch URL to
+/// a delegate that already responds to the selector, and the runtime that
+/// registers the handler starts well after the app finishes launching.
+/// Returns false if winit's delegate class couldn't be located.
+#[cfg(target_os = "macos")]
+pub fn install_delegate_methods() -> bool {
+  mac::install_delegate_methods()
+}
+
+/// Register (or, with `None`, clear) the open-url handler and flush anything
+/// buffered while none was set. Clearing re-arms buffering and leaves the
+/// queue intact for the next registration.
+pub fn set_handler(handler: Option<(LaufeyOpenUrlFn, usize)>) {
+  // Install as early as possible: AppKit only routes the launch URL to a
+  // delegate that already responds to the selector.
+  #[cfg(target_os = "macos")]
+  mac::install_delegate_methods();
+
+  let flushed = {
+    let mut slot = HANDLER.lock().unwrap();
+    *slot = handler;
+    if handler.is_some() {
+      std::mem::take(&mut *PENDING.lock().unwrap())
+    } else {
+      Vec::new()
+    }
+  };
+
+  // Outside the lock — the handler is embedder code and may re-enter. Note
+  // this runs on the registering thread, not the UI thread; it's the one case
+  // where an open-url callback fires anywhere else.
+  if let Some((callback, data)) = handler {
+    for url in flushed {
+      unsafe { callback(data as *mut c_void, url.as_ptr()) };
+    }
+  }
+}
+
+/// Deliver `url` to the registered handler, or buffer it until one registers.
+pub fn fire(url: &str) {
+  // A URL with an interior NUL can't cross the C ABI; drop it rather than
+  // truncating into a different URL than the user clicked.
+  let Ok(c_url) = CString::new(url) else {
+    return;
+  };
+
+  let handler = {
+    let slot = HANDLER.lock().unwrap();
+    match *slot {
+      Some(handler) => Some(handler),
+      None => {
+        // Push while still holding HANDLER, so a concurrent set_handler
+        // can't flush an empty queue and strand this URL.
+        let mut pending = PENDING.lock().unwrap();
+        if pending.len() >= MAX_PENDING {
+          // Drop the oldest: the most recent link is the one the user is
+          // waiting on.
+          pending.remove(0);
+        }
+        pending.push(c_url.clone());
+        None
+      }
+    }
+  };
+
+  if let Some((callback, data)) = handler {
+    unsafe { callback(data as *mut c_void, c_url.as_ptr()) };
+  }
+}
+
+/// Backs the `test_trigger_open_url` C ABI hook. Returns true if a handler
+/// consumed the URL, false if it was buffered for a later registration.
+pub fn test_trigger(url: &str) -> bool {
+  let delivered = HANDLER.lock().unwrap().is_some();
+  fire(url);
+  delivered
+}
+
+#[cfg(target_os = "macos")]
+mod mac {
+  use objc2::runtime::{AnyClass, AnyObject, Imp, Sel};
+  use objc2::sel;
+  use objc2_foundation::{NSArray, NSURL};
+  use std::sync::Once;
+
+  /// Runtime-add `application:openURLs:` to winit's `NSApplicationDelegate`
+  /// subclass. Idempotent; safe to call repeatedly. Returns false if the
+  /// delegate class couldn't be located.
+  pub fn install_delegate_methods() -> bool {
+    static INSTALL: Once = Once::new();
+    static mut INSTALLED: bool = false;
+
+    INSTALL.call_once(|| {
+      // SAFETY: accessing the static is gated by Once.
+      unsafe {
+        INSTALLED = try_install();
+      }
+      // SAFETY: same — reading inside Once.
+      if unsafe { !INSTALLED } {
+        eprintln!(
+          "laufey: failed to install the open-url delegate method on winit's \
+           NSApplicationDelegate — deep links will not fire. This likely \
+           means winit changed its delegate class name."
+        );
+      }
+    });
+    // SAFETY: once initialized by Once, the value is stable.
+    unsafe { INSTALLED }
+  }
+
+  fn try_install() -> bool {
+    // Same class winit 0.30 uses for the dock methods; see dock.rs.
+    let Some(cls) = AnyClass::get(c"WinitApplicationDelegate") else {
+      return false;
+    };
+
+    // Cast to *mut to allow runtime modification.
+    let raw_cls = cls as *const _ as *mut _;
+
+    // SAFETY: the trampoline's real signature matches what AppKit invokes
+    // for this selector — (void)(id, SEL, NSApplication*, NSArray*) — which
+    // is what the "v@:@@" encoding declares.
+    unsafe {
+      let imp: Imp =
+        std::mem::transmute(application_open_urls_imp as *const ());
+      // class_addMethod returns false if the selector already exists —
+      // silently OK: a future winit may implement it itself.
+      let _ = objc2::ffi::class_addMethod(
+        raw_cls,
+        sel!(application:openURLs:),
+        imp,
+        c"v@:@@".as_ptr(),
+      );
+    }
+    true
+  }
+
+  /// Trampoline:
+  /// `- (void)application:(NSApplication*)app openURLs:(NSArray<NSURL*>*)urls`
+  unsafe extern "C-unwind" fn application_open_urls_imp(
+    _self: *mut AnyObject,
+    _sel: Sel,
+    _app: *mut AnyObject,
+    urls: *mut AnyObject,
+  ) {
+    // SAFETY: AppKit passes a non-null NSArray<NSURL*> for this selector;
+    // the null check covers a malformed caller.
+    let urls = urls.cast::<NSArray<NSURL>>();
+    let Some(urls) = (unsafe { urls.as_ref() }) else {
+      return;
+    };
+    for index in 0..urls.count() {
+      let url = urls.objectAtIndex(index);
+      if let Some(absolute) = url.absoluteString() {
+        super::fire(&absolute.to_string());
+      }
+    }
+  }
+}

--- a/capi/include/laufey.h
+++ b/capi/include/laufey.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-#define LAUFEY_API_VERSION 34
+#define LAUFEY_API_VERSION 35
 
 // Window handle types for get_window_handle_type
 #define LAUFEY_WINDOW_HANDLE_UNKNOWN 0
@@ -126,11 +126,24 @@ typedef void (*laufey_menu_click_fn)(void* user_data, uint32_t window_id,
 #define LAUFEY_DOCK_BOUNCE_INFORMATIONAL 10
 #define LAUFEY_DOCK_BOUNCE_CRITICAL 0
 
+// How many deep-link URLs a backend buffers while no open-url handler is
+// registered (see set_open_url_handler). A cold start delivers one; the cap
+// only bounds a pathological burst of links clicked before the runtime is up.
+#define LAUFEY_MAX_PENDING_OPEN_URLS 16
+
 // Callback fired when the user clicks the dock / taskbar icon for an app that
 // has no visible windows (macOS only; Windows/Linux have no equivalent event).
 // has_visible_windows is true if any app window is currently on-screen.
 typedef void (*laufey_dock_reopen_fn)(void* user_data,
                                       bool has_visible_windows);
+
+// Callback fired when the OS routes a custom URL scheme (deep link) to this
+// app — e.g. `acme://open/document/42` — either at launch or while the app is
+// already running (macOS only; see set_open_url_handler). `url` is the full
+// URL as the OS delivered it, valid only for the duration of the call, and
+// NOT validated: the embedder must check the scheme against the ones it
+// registered before acting on it.
+typedef void (*laufey_open_url_fn)(void* user_data, const char* url);
 
 // Callback fired when the user left-clicks a tray / status-bar icon.
 // (Right-click is reserved for the tray's menu.)
@@ -841,6 +854,52 @@ struct laufey_backend_api {
   // false if the id is unknown or the backend doesn't support forwarding.
   // NULL on backends older than API version 34.
   bool (*is_click_passthrough_forward)(void* backend_data, uint32_t window_id);
+
+  // --- Deep links / custom URL schemes (API >= 35) ---------------------------
+  //
+  // Register a callback invoked when the OS routes a custom URL scheme this
+  // app has registered — `acme://open/document/42` — to the app. Registering
+  // the scheme itself is NOT laufey's job: the embedder declares it in the
+  // bundle it ships (macOS `CFBundleURLTypes`, Linux `.desktop`
+  // `x-scheme-handler/<scheme>`, Windows `HKCU\Software\Classes\<scheme>`).
+  // See docs/deep-links.md.
+  //
+  // macOS only, for the same reason as set_dock_reopen_handler: AppKit
+  // delivers the URL to the *running* app as an Apple Event
+  // (`application:openURLs:`), so one process handles every link. Windows and
+  // Linux have no equivalent — the OS spawns a NEW process with the URL in
+  // argv, and turning that into "focus the running app" needs a
+  // single-instance lock, an app identity, and a policy on whether a second
+  // instance is even wrong. All three belong to the embedder that owns the
+  // packaging, so those backends leave this pointer NULL and the embedder
+  // reads its own argv.
+  //
+  // Delivery contract:
+  //   - URLs that arrive before a handler is registered are buffered and
+  //     flushed, in order, as soon as one is. A runtime loaded on a worker
+  //     thread is never ready when a launch URL lands, so without this every
+  //     cold-start deep link would be dropped. At most
+  //     LAUFEY_MAX_PENDING_OPEN_URLS are held; older ones are discarded.
+  //   - The callback fires on the backend UI thread, synchronously, like
+  //     every other event handler.
+  //   - Passing a NULL `fn` clears the handler and re-arms buffering.
+  //   - macOS hands over an array of URLs; the backend fans it out into one
+  //     call per URL.
+  //
+  // NULL on backends older than API version 35; callers must null-check.
+  void (*set_open_url_handler)(void* backend_data, laufey_open_url_fn fn,
+                               void* user_data);
+
+  // Test-only. Synthesizes a deep-link delivery of `url` through the same
+  // dispatch path a real OS-routed URL takes — including the buffer, so a
+  // call made before any handler is registered is replayed on registration
+  // just like a cold-start URL. Returns true if the URL was delivered to a
+  // registered handler, false if it was buffered instead. Lets automated e2e
+  // tests cover the round-trip without OS-level scheme registration or Apple
+  // Events. NULL on backends that don't implement it (API < 35, or any
+  // non-macOS backend); callers should treat a NULL hook as unavailable,
+  // like test_click_menu_item.
+  bool (*test_trigger_open_url)(void* backend_data, const char* url);
 };
 
 #ifdef __cplusplus

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -29,7 +29,7 @@ pub use mouse::*;
 /// (`github.com/denoland/laufey/releases/tag/v{VERSION}`).
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub const LAUFEY_API_VERSION: u32 = 34;
+pub const LAUFEY_API_VERSION: u32 = 35;
 
 /// Creation-time window style flags for [`Window::new_with_options`].
 /// Mirror the `LAUFEY_WINDOW_FLAG_*` constants in `laufey.h`.
@@ -67,6 +67,9 @@ static DOCK_MENU_HANDLER: OnceLock<
 > = OnceLock::new();
 static DOCK_REOPEN_HANDLER: OnceLock<
   Mutex<Option<Box<dyn Fn(bool) + Send + Sync>>>,
+> = OnceLock::new();
+static OPEN_URL_HANDLER: OnceLock<
+  Mutex<Option<Box<dyn Fn(&str) + Send + Sync>>>,
 > = OnceLock::new();
 static TRAY_MENU_HANDLERS: OnceLock<
   Mutex<HashMap<u32, Box<dyn Fn(&str) + Send + Sync>>>,
@@ -1652,6 +1655,28 @@ pub fn test_trigger_close_requested(window_id: u32) -> bool {
   unsafe { f(api.backend_data, window_id) }
 }
 
+/// Test-only. Synthesizes a deep-link delivery of `url` through the same
+/// dispatch path a real OS-routed URL takes, buffer included: called before
+/// any [`on_open_url`] handler is registered, the URL is replayed on
+/// registration exactly like a cold-start link. Returns `true` if a handler
+/// consumed it, `false` if it was buffered — or if the backend does not
+/// implement the test hook (API < 35, or any non-macOS backend).
+///
+/// Intended for automated e2e tests, so a deep-link round-trip can be covered
+/// without registering a URL scheme with the OS. See `examples/native_e2e`
+/// and `docs/e2e-testing.md`.
+pub fn test_trigger_open_url(url: &str) -> bool {
+  let api = api();
+  let Some(f) = api.test_trigger_open_url else {
+    return false;
+  };
+  let Ok(c_url) = CString::new(url) else {
+    return false;
+  };
+  // SAFETY: `c_url` outlives the call; the backend only reads the string.
+  unsafe { f(api.backend_data, c_url.as_ptr()) }
+}
+
 /// A menu item in an application menu template.
 #[derive(Clone, Debug)]
 pub enum MenuItem {
@@ -1936,6 +1961,72 @@ where
       f(
         api.backend_data,
         Some(dock_reopen_callback),
+        std::ptr::null_mut(),
+      );
+    }
+  }
+}
+
+// --- Deep links / custom URL schemes ---
+
+fn open_url_handler() -> &'static Mutex<Option<Box<dyn Fn(&str) + Send + Sync>>>
+{
+  OPEN_URL_HANDLER.get_or_init(|| Mutex::new(None))
+}
+
+unsafe extern "C" fn open_url_callback(
+  _user_data: *mut c_void,
+  url: *const c_char,
+) {
+  if url.is_null() {
+    return;
+  }
+  // The OS is the source here, so don't assume well-formed UTF-8.
+  let url = CStr::from_ptr(url).to_string_lossy();
+  if let Some(handler) = open_url_handler().lock().unwrap().as_ref() {
+    handler(&url);
+  }
+}
+
+/// Register a callback invoked when the OS routes a custom URL scheme this app
+/// has registered — `acme://open/document/42` — to the app, either at launch
+/// or while it is already running.
+///
+/// Registering the scheme with the OS is *not* laufey's job: the embedder
+/// declares it in the bundle it ships (macOS `CFBundleURLTypes`, Linux
+/// `.desktop` `x-scheme-handler/<scheme>`, Windows
+/// `HKCU\Software\Classes\<scheme>`). See `docs/deep-links.md`.
+///
+/// URLs that arrive before this is called — which a launch URL always does,
+/// since the runtime is still coming up — are buffered by the backend and
+/// delivered as soon as the handler is registered.
+///
+/// The URL is whatever the OS handed over, unvalidated: check the scheme
+/// against the ones you registered before acting on it.
+///
+/// macOS only, for the same reason as [`on_dock_reopen`]: AppKit delivers the
+/// URL to the running app as an Apple Event, so one process handles every
+/// link. Windows and Linux spawn a new process with the URL in argv instead,
+/// which needs a single-instance lock and an app identity that only the
+/// embedder has — read `std::env::args` there. No-op on those platforms.
+pub fn on_open_url<F>(handler: F)
+where
+  F: Fn(&str) + Send + Sync + 'static,
+{
+  // Install the Rust-side handler first: the backend flushes buffered URLs
+  // synchronously inside the call below, and they'd be dropped if the slot
+  // were still empty.
+  {
+    let mut slot = open_url_handler().lock().unwrap();
+    *slot = Some(Box::new(handler));
+  }
+
+  let api = api();
+  if let Some(f) = api.set_open_url_handler {
+    unsafe {
+      f(
+        api.backend_data,
+        Some(open_url_callback),
         std::ptr::null_mut(),
       );
     }

--- a/cef/src/main_mac.mm
+++ b/cef/src/main_mac.mm
@@ -115,6 +115,25 @@ void LaufeyOpenExternalURL(const std::string& url) {
   return NO;
 }
 
+// Deep links. AppKit routes the kAEGetURL Apple Event here for every scheme
+// the bundle claims in CFBundleURLTypes, both at launch and while running.
+// Implementing this selector is what makes AppKit install its own handler for
+// that event, so there's no NSAppleEventManager registration to do.
+//
+// This delegate is installed before [NSApp run], so no launch URL is missed:
+// AppKit can't dispatch the event before the run loop starts. It can still
+// arrive before the runtime registers a handler, which is what the buffer in
+// FireOpenUrlMac covers.
+- (void)application:(NSApplication*)application
+           openURLs:(NSArray<NSURL*>*)urls {
+  for (NSURL* url in urls) {
+    NSString* absolute = [url absoluteString];
+    if (absolute) {
+      laufey_common::FireOpenUrlMac([absolute UTF8String]);
+    }
+  }
+}
+
 - (NSMenu*)applicationDockMenu:(NSApplication*)sender {
   return laufey_common::GetDockMenuMac();
 }

--- a/cef/src/runtime_loader.cc
+++ b/cef/src/runtime_loader.cc
@@ -1097,6 +1097,10 @@ extern void Backend_SetDockVisible_Mac(void* data, bool visible);
 extern void Backend_SetDockReopenHandler_Mac(void* data,
                                              laufey_dock_reopen_fn handler,
                                              void* user_data);
+extern void Backend_SetOpenUrlHandler_Mac(void* data,
+                                          laufey_open_url_fn handler,
+                                          void* user_data);
+extern bool Backend_TestTriggerOpenUrl_Mac(void* data, const char* url);
 
 extern uint32_t Backend_CreateTrayIcon_Mac(void* data);
 extern void Backend_DestroyTrayIcon_Mac(void* data, uint32_t tray_id);
@@ -1883,6 +1887,12 @@ void RuntimeLoader::InitializeBackendApi() {
   backend_api_.set_dock_menu = Backend_SetDockMenu_Mac;
   backend_api_.set_dock_visible = Backend_SetDockVisible_Mac;
   backend_api_.set_dock_reopen_handler = Backend_SetDockReopenHandler_Mac;
+  // Deep links: macOS-only by design (see set_open_url_handler in laufey.h).
+  // Windows/Linux receive the URL as argv in a new process, which only the
+  // embedder can turn into "focus the running app", so the pointers stay
+  // NULL there and an embedder can detect the absence.
+  backend_api_.set_open_url_handler = Backend_SetOpenUrlHandler_Mac;
+  backend_api_.test_trigger_open_url = Backend_TestTriggerOpenUrl_Mac;
 #elif defined(_WIN32)
   backend_api_.bounce_dock = Backend_BounceDock_Win;
   backend_api_.set_dock_badge = Backend_SetDockBadge_TitlePrefix;

--- a/cef/src/runtime_loader_mac.mm
+++ b/cef/src/runtime_loader_mac.mm
@@ -738,6 +738,20 @@ void Backend_SetDockReopenHandler_Mac(void* /*data*/,
   laufey_common::SetDockReopenHandlerMac(handler, user_data);
 }
 
+// --- Deep links / custom URL schemes (macOS) ---
+//
+// Storage and the cold-start buffer live in backend-common;
+// LaufeyAppDelegate's application:openURLs: (main_mac.mm) is what feeds them.
+
+void Backend_SetOpenUrlHandler_Mac(void* /*data*/, laufey_open_url_fn handler,
+                                   void* user_data) {
+  laufey_common::SetOpenUrlHandlerMac(handler, user_data);
+}
+
+bool Backend_TestTriggerOpenUrl_Mac(void* /*data*/, const char* url) {
+  return laufey_common::TestTriggerOpenUrlMac(url);
+}
+
 // --- Tray / status-bar icon (macOS) ---
 //
 // Thin trampolines over backend-common/src/tray_mac.mm.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -14,6 +14,7 @@
 - [Window events](window-events.md)
 - [Window handles](window-handles.md)
 - [Dock / taskbar](dock-taskbar.md)
+- [Deep links](deep-links.md)
 - [Tray / status bar](tray.md)
 - [Notifications](notifications.md)
 - [Clipboard](clipboard.md)

--- a/docs/c-abi.md
+++ b/docs/c-abi.md
@@ -6,7 +6,7 @@ It defines the boundary between a **backend** (a native executable embedding a
 browser engine) and a **runtime** (a shared library holding the application
 logic). The backend implements the ABI; the runtime consumes it.
 
-`LAUFEY_API_VERSION` (currently `31`) versions the contract. The `version` field
+`LAUFEY_API_VERSION` (currently `35`) versions the contract. The `version` field
 on the API table lets a runtime detect the backend's vintage and avoid calling
 function pointers a backend predates (older backends leave new pointers `NULL`).
 
@@ -64,6 +64,8 @@ The pointers group into:
 - **Dialogs** — `show_dialog`, `string_free`.
 - **Dock / taskbar** — `set_dock_badge`, `bounce_dock`, `set_dock_menu`,
   `set_dock_visible`, `set_dock_reopen_handler`.
+- **Deep links** (API ≥ 35) — `set_open_url_handler`, macOS-only and buffered
+  until a handler registers (see [deep-links.md](deep-links.md)).
 - **Tray** — `create_tray_icon`, `destroy_tray_icon`, `set_tray_icon`(`_dark`),
   `set_tray_tooltip`, `set_tray_menu`, click handlers, `get_tray_icon_bounds`.
 - **Notifications** — `show_notification`, `close_notification`.

--- a/docs/deep-links.md
+++ b/docs/deep-links.md
@@ -1,0 +1,114 @@
+# Deep links
+
+A deep link is a custom URL scheme the OS routes to your app — clicking
+`acme://open/document/42` in a browser, a mail client, or a terminal hands that
+URL to the app that claims the `acme` scheme. laufey delivers the URL to your
+runtime; it does not register the scheme.
+
+```rust
+laufey::on_open_url(|url| {
+  // "acme://open/document/42"
+  window.navigate(&route_for(url));
+});
+```
+
+## Registering the scheme is the embedder's job
+
+laufey [does not build application bundles](distribution.md), and scheme
+registration lives entirely inside the bundle metadata, so it belongs to
+whatever packages the app:
+
+| Platform | Where the scheme is declared                                              |
+| -------- | ------------------------------------------------------------------------- |
+| macOS    | `CFBundleURLTypes` / `CFBundleURLSchemes` in the bundle `Info.plist`      |
+| Linux    | `MimeType=x-scheme-handler/acme;` plus `Exec=… %u` in the `.desktop`      |
+| Windows  | `HKCU\Software\Classes\acme` with `URL Protocol` and `shell\open\command` |
+
+The OS also has to have _seen_ that metadata: macOS registers schemes through
+LaunchServices when the `.app` is installed (or after `lsregister -f`), Linux
+needs the `.desktop` file in `~/.local/share/applications` and
+`update-desktop-database`, and the Windows keys are normally written by an
+installer.
+
+## macOS only, and why
+
+`on_open_url` fires on macOS. Windows and Linux are a no-op.
+
+This isn't an implementation gap — the platforms hand deep links over in
+fundamentally different shapes. macOS delivers the URL to the _already running_
+app as an Apple Event (`application:openURLs:`), launching it first if
+necessary, so a single process sees every link and laufey can turn that into a
+callback.
+
+Windows and Linux instead **spawn a new process** with the URL in `argv`. Making
+that behave like a deep link means recognizing the second process as a
+duplicate, forwarding the URL to the first one, and raising its window — which
+needs a single-instance lock keyed to a stable app identity, and a decision
+about whether a second instance is wrong at all. laufey has neither the identity
+nor the standing to make that call, for the same reason it doesn't bundle or
+sign: the embedder owns packaging. So on those platforms the embedder reads
+`std::env::args()` itself and does its own forwarding.
+
+Backends report this through the ABI: `set_open_url_handler` is `NULL` on every
+non-macOS backend, so an embedder can detect the absence rather than register a
+handler that silently never fires.
+
+## Cold start is buffered, not dropped
+
+A launch URL — the case where clicking the link _starts_ the app — arrives while
+the runtime is still coming up. The backend loads the runtime shared library on
+a worker thread, so at the moment AppKit dispatches the Apple Event there is no
+handler to call yet.
+
+Rather than lose it, the backend buffers URLs while no handler is registered and
+flushes them, in order, the instant `on_open_url` is called. Registering a
+handler at startup is therefore enough to catch both cases:
+
+```rust
+// Fires for a link clicked five minutes from now, and for the link that
+// launched the app a moment ago.
+laufey::on_open_url(|url| handle(url));
+```
+
+Up to `LAUFEY_MAX_PENDING_OPEN_URLS` (16) URLs are held; beyond that the oldest
+are discarded, since the newest link is the one the user is waiting on.
+
+## Threading
+
+The callback runs on the backend's UI thread, like every other event handler —
+with one exception: URLs replayed from the buffer run on the thread that called
+`on_open_url`, because the flush happens inside that call.
+
+## Validate the URL
+
+The URL is passed through exactly as the OS delivered it, with no filtering.
+Anything on the machine can invoke your app with an arbitrary URL, so treat it
+as untrusted input: check the scheme against the one you registered, and don't
+route on it without validating the rest.
+
+```rust
+laufey::on_open_url(|url| {
+  let Some(rest) = url.strip_prefix("acme://") else {
+    return; // not ours
+  };
+  route(rest);
+});
+```
+
+## Testing
+
+Deep links need OS-level registration to exercise for real, which automated
+tests can't rely on. The `test_trigger_open_url` hook (API ≥ 35) synthesizes a
+delivery through the same dispatch path — buffer included, so a call made before
+any handler is registered is replayed on registration exactly like a cold start:
+
+```rust
+assert!(!laufey::test_trigger_open_url("acme://cold")); // buffered
+laufey::on_open_url(|url| { /* receives "acme://cold" immediately */ });
+assert!(laufey::test_trigger_open_url("acme://live")); // delivered
+```
+
+See [`docs/e2e-testing.md`](e2e-testing.md) and the probe in
+`examples/native_e2e`. For an end-to-end check, build a bundle with a scheme in
+its `Info.plist`, register it with `lsregister -f`, and `open 'acme://…'` with
+the app both running and closed.

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -28,7 +28,11 @@ matrix over the C ABI surface, and a phased rollout.
 > (API 31, `§8`) for `set_close_requested_handler`'s defer-until-close_window
 > contract is implemented for all backends and verified green under Winit and
 > WebView on macOS; it rides the same pre-existing CI exclusions above for CEF
-> and the Windows/Linux webview combos, so those aren't gated by it yet.
+> and the Windows/Linux webview combos, so those aren't gated by it yet. The
+> `test_trigger_open_url` hook (API 35, `§8`) for deep-link delivery is
+> implemented wherever deep links are — macOS, for all three backends — and
+> verified green under Winit and WebView there; it reports `N/A` on every other
+> platform, where the ABI pointer is NULL by design.
 
 ---
 
@@ -402,6 +406,31 @@ on macOS; CEF and the Windows/Linux webview backends implement the same plumbing
 but ride the pre-existing `native-e2e` CI exclusions for those combos (`§`
 status note above) — not gated by this change, but not covered by CI for it
 either.
+
+**Implemented (API 35):**
+
+```c
+// Synthesizes a deep-link delivery of `url` through the same dispatch path
+// a real OS-routed URL takes, buffer included: called before any handler is
+// registered, the URL is replayed on registration exactly like a cold-start
+// launch link. Returns true if a handler consumed it, false if it was
+// buffered. NULL on every non-macOS backend (see docs/deep-links.md).
+bool (*test_trigger_open_url)(void* backend_data, const char* url);
+```
+
+Deep links can't be exercised for real without registering a URL scheme with the
+OS and driving it from outside the process — exactly the kind of setup this
+strategy avoids. The hook routes through `FireOpenUrlMac` (CEF + WebView) /
+`open_url::fire` (Winit), the same functions each backend's
+`application:openURLs:` delegate method calls, so the buffer-and-flush behavior
+under test is the shipping one.
+
+The capi exposes `laufey::test_trigger_open_url(url)`. The `native_e2e` runtime
+triggers one URL _before_ registering a handler — the position every cold-start
+launch URL is in — then registers, and asserts the buffered URL was replayed,
+that a subsequent URL is delivered live, and that neither was duplicated or
+lost. Verified green under WebView and Winit on macOS; `N/A` everywhere else,
+where the pointer is NULL by design rather than by omission.
 
 **Not yet added** (future hooks, same append-and-`N/A` pattern):
 

--- a/examples/hello/src/lib.rs
+++ b/examples/hello/src/lib.rs
@@ -7,6 +7,13 @@ fn hello_main() {
       println!("dock reopen fired; has_visible_windows = {}", has_visible);
     });
 
+    // Deep links. Fires for `hello://…` once the bundle claims the scheme in
+    // its Info.plist — including the URL that launched the app, which is
+    // buffered until this handler exists. See docs/deep-links.md.
+    laufey::on_open_url(|url| {
+      println!("open url: {url}");
+    });
+
     // BADGE-DIAGNOSIS: tray temporarily disabled.
     // let _tray = ...;
 

--- a/examples/native_e2e/src/lib.rs
+++ b/examples/native_e2e/src/lib.rs
@@ -522,6 +522,56 @@ fn e2e_main() {
       );
     }
 
+    // ---- deep-link (open-url) round-trip -----------------------------------
+    // Capability-probed: the hook is NULL on every non-macOS backend, where
+    // the OS hands deep links to a new process as argv instead of to the
+    // running one (see set_open_url_handler in laufey.h).
+    //
+    // Covers both halves of the delivery contract. The first trigger runs
+    // *before* any handler is registered — the position every cold-start
+    // launch URL is in, since the runtime is still coming up when the OS
+    // routes it — so it must be buffered and replayed on registration, not
+    // dropped.
+    const COLD_URL: &str = "laufeytest://open/document/42";
+    const LIVE_URL: &str = "laufeytest://open/document/43?q=1";
+
+    let seen_urls: Arc<std::sync::Mutex<Vec<String>>> =
+      Arc::new(std::sync::Mutex::new(Vec::new()));
+    let buffered_not_delivered = !laufey::test_trigger_open_url(COLD_URL);
+    {
+      let seen = seen_urls.clone();
+      laufey::on_open_url(move |url| {
+        seen.lock().unwrap().push(url.to_string());
+      });
+    }
+    // Both the flush above and this trigger dispatch synchronously on this
+    // thread, so the assertions below need no waiting.
+    let delivered_live = laufey::test_trigger_open_url(LIVE_URL);
+    let urls = seen_urls.lock().unwrap().clone();
+
+    if !delivered_live && urls.is_empty() {
+      // A registered handler that receives nothing means the hook is absent
+      // (non-macOS backend), not that dispatch is broken.
+      na("deep links (test_trigger_open_url unavailable on this backend)");
+    } else {
+      check(
+        "URL arriving before any handler is buffered, not delivered",
+        buffered_not_delivered,
+      );
+      check(
+        "buffered cold-start URL is replayed on registration",
+        urls.first().map(String::as_str) == Some(COLD_URL),
+      );
+      check(
+        "URL arriving with a handler registered is delivered live",
+        delivered_live && urls.iter().any(|u| u == LIVE_URL),
+      );
+      check(
+        "no URL is delivered twice or lost",
+        urls.len() == 2,
+      );
+    }
+
     // ---- Layer-1 hold ----------------------------------------------------
     // When driven by the D-Bus observer (native_e2e_driver), stay alive with
     // the tray + menu registered so it can read the StatusNotifierItem, walk

--- a/webview/src/main_mac.mm
+++ b/webview/src/main_mac.mm
@@ -145,6 +145,23 @@ void EnsureEditMenu(NSMenu* menubar) {
   return NO;
 }
 
+// Deep links. AppKit routes the kAEGetURL Apple Event here for every scheme
+// the bundle claims in CFBundleURLTypes, both at launch and while running.
+// Implementing this selector is what makes AppKit install its own handler for
+// that event, so there's no NSAppleEventManager registration to do.
+//
+// A launch URL lands before the runtime finished loading on its worker
+// thread, so FireOpenUrlMac buffers until a handler registers.
+- (void)application:(NSApplication*)application
+           openURLs:(NSArray<NSURL*>*)urls {
+  for (NSURL* url in urls) {
+    NSString* absolute = [url absoluteString];
+    if (absolute) {
+      laufey_common::FireOpenUrlMac([absolute UTF8String]);
+    }
+  }
+}
+
 - (NSMenu*)applicationDockMenu:(NSApplication*)sender {
   return laufey_common::GetDockMenuMac();
 }

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -645,6 +645,27 @@ static void Backend_SetDockReopenHandler(void* data,
   }
 }
 
+// --- Deep links / custom URL schemes (macOS only) ---
+#if defined(__APPLE__)
+
+static void Backend_SetOpenUrlHandler(void* data, laufey_open_url_fn handler,
+                                      void* user_data) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  if (LaufeyBackend* backend = loader->GetBackend()) {
+    backend->SetOpenUrlHandler(handler, user_data);
+  }
+}
+
+static bool Backend_TestTriggerOpenUrl(void* data, const char* url) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  if (LaufeyBackend* backend = loader->GetBackend()) {
+    return backend->TestTriggerOpenUrl(url);
+  }
+  return false;
+}
+
+#endif  // defined(__APPLE__)
+
 // --- Tray / status bar ---
 
 static uint32_t Backend_CreateTrayIcon(void* data) {
@@ -843,6 +864,14 @@ void RuntimeLoader::InitializeBackendApi() {
   backend_api_.set_dock_menu = Backend_SetDockMenu;
   backend_api_.set_dock_visible = Backend_SetDockVisible;
   backend_api_.set_dock_reopen_handler = Backend_SetDockReopenHandler;
+
+  // Deep links are macOS-only (see set_open_url_handler in laufey.h). Leave
+  // the pointers NULL elsewhere so an embedder can detect the absence rather
+  // than register a handler that silently never fires.
+#if defined(__APPLE__)
+  backend_api_.set_open_url_handler = Backend_SetOpenUrlHandler;
+  backend_api_.test_trigger_open_url = Backend_TestTriggerOpenUrl;
+#endif
 
   backend_api_.create_tray_icon = Backend_CreateTrayIcon;
   backend_api_.destroy_tray_icon = Backend_DestroyTrayIcon;

--- a/webview/src/runtime_loader.h
+++ b/webview/src/runtime_loader.h
@@ -513,6 +513,16 @@ class LaufeyBackend {
   virtual void SetDockReopenHandler(laufey_dock_reopen_fn /*handler*/,
                                     void* /*user_data*/) {}
 
+  // --- Deep links / custom URL schemes ---
+  // macOS only (AppKit's application:openURLs:); Windows/Linux get the URL as
+  // argv in a brand-new process, which is the embedder's to handle. The
+  // default no-op leaves the C ABI pointer inert on those platforms.
+  virtual void SetOpenUrlHandler(laufey_open_url_fn /*handler*/,
+                                 void* /*user_data*/) {}
+  virtual bool TestTriggerOpenUrl(const char* /*url*/) {
+    return false;
+  }
+
   // --- Tray / status-bar icon ---
   virtual uint32_t CreateTrayIcon() {
     return 0;

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -125,6 +125,9 @@ class WKWebViewBackend : public LaufeyBackend {
   void SetDockReopenHandler(laufey_dock_reopen_fn handler,
                             void* user_data) override;
 
+  void SetOpenUrlHandler(laufey_open_url_fn handler, void* user_data) override;
+  bool TestTriggerOpenUrl(const char* url) override;
+
   uint32_t CreateTrayIcon() override;
   void DestroyTrayIcon(uint32_t tray_id) override;
   void SetTrayIcon(uint32_t tray_id, const void* png_bytes,
@@ -2072,6 +2075,20 @@ void WKWebViewBackend::SetDockVisible(bool visible) {
 void WKWebViewBackend::SetDockReopenHandler(laufey_dock_reopen_fn handler,
                                             void* user_data) {
   laufey_common::SetDockReopenHandlerMac(handler, user_data);
+}
+
+// --- Deep links / custom URL schemes (macOS) ---
+//
+// Storage and the cold-start buffer live in backend-common; AppDelegate's
+// application:openURLs: (main_mac.mm) is what feeds them.
+
+void WKWebViewBackend::SetOpenUrlHandler(laufey_open_url_fn handler,
+                                         void* user_data) {
+  laufey_common::SetOpenUrlHandlerMac(handler, user_data);
+}
+
+bool WKWebViewBackend::TestTriggerOpenUrl(const char* url) {
+  return laufey_common::TestTriggerOpenUrlMac(url);
 }
 
 // --- Tray / status-bar icon (macOS) ---


### PR DESCRIPTION
Adds set_open_url_handler / laufey_open_url_fn to the backend C ABI (API 35), delivering an OS-routed custom URL scheme (acme://open/document/42) to the runtime as a callback.

macOS only, like set_dock_reopen_handler: AppKit hands the URL to the running app as an Apple Event. Windows and Linux spawn a new process with it in argv, which needs a single-instance lock and an app identity the embedder owns — they
leave the pointer NULL.

URLs arriving before a handler registers are buffered and flushed on registration; a launch URL always lands while the runtime is still starting, so otherwise every cold-start link is lost. Scheme registration stays the embedder's job (docs/deep-links.md).

Rust API: laufey::on_open_url(|url| …), plus a test_trigger_open_url hook covering the round-trip (buffer included) in native_e2e — green under WebView, CEF, and Winit on macOS.