### PR TITLE
feat(winit): add IME setters and composition events

### DIFF
--- a/backend-common/CMakeLists.txt
+++ b/backend-common/CMakeLists.txt
@@ -63,6 +63,7 @@ elseif(UNIX)
 elseif(WIN32)
   list(APPEND LAUFEY_COMMON_SRCS
     src/strings_win.cc
+    src/ime_win.cc
     src/notifications_win.cc
     src/dialog_win.cc
     src/clipboard_win.cc
@@ -86,6 +87,7 @@ if(WIN32)
     shell32
     gdi32
     user32
+    imm32
   )
 elseif(APPLE)
   find_library(USERNOTIFICATIONS_FRAMEWORK UserNotifications REQUIRED)

--- a/backend-common/include/ime_key_echo.h
+++ b/backend-common/include/ime_key_echo.h
@@ -13,30 +13,36 @@
 namespace laufey_common {
 
 struct ImeKeyEcho {
-  std::string key;
   std::string code;
   std::chrono::steady_clock::time_point time{};
   bool valid = false;
 };
 
-inline bool ConsumeImeKeyEcho(ImeKeyEcho* last, int state, const char* key,
+// `last` is the press that has not been released yet. An echo is an extra
+// keydown of that same physical key with no keyup between.
+inline bool ConsumeImeKeyEcho(ImeKeyEcho* last, int state, bool repeat,
                               const char* code) {
-  if (!last || state != LAUFEY_KEY_PRESSED) {
+  if (!last) {
+    return false;
+  }
+  std::string c = code ? code : "";
+  if (state != LAUFEY_KEY_PRESSED) {
+    if (last->valid && last->code == c) {
+      last->valid = false;
+    }
+    return false;
+  }
+  // Windows' fastest auto-repeat is ~33ms, inside the 40ms window.
+  if (repeat) {
     return false;
   }
   auto now = std::chrono::steady_clock::now();
-  std::string k = key ? key : "";
-  std::string c = code ? code : "";
+  // Match `code` only. IME-consumed keys all report logical key "Process".
   if (last->valid &&
-      (now - last->time) < std::chrono::milliseconds(40)) {
-    bool same_code =
-        !c.empty() && c != "Unidentified" && c == last->code;
-    bool same_key = !k.empty() && k != "Unidentified" && k == last->key;
-    if (same_code || same_key) {
-      return true;
-    }
+      (now - last->time) < std::chrono::milliseconds(40) && !c.empty() &&
+      c != "Unidentified" && c == last->code) {
+    return true;
   }
-  last->key = std::move(k);
   last->code = std::move(c);
   last->time = now;
   last->valid = true;

--- a/backend-common/include/ime_key_echo.h
+++ b/backend-common/include/ime_key_echo.h
@@ -1,0 +1,48 @@
+// Copyright 2025 Divy Srivastava. All rights reserved. MIT license.
+//
+// Drop the extra keyDown Japanese IMEs post for the same physical key.
+
+#ifndef LAUFEY_IME_KEY_ECHO_H_
+#define LAUFEY_IME_KEY_ECHO_H_
+
+#include <laufey.h>
+
+#include <chrono>
+#include <string>
+
+namespace laufey_common {
+
+struct ImeKeyEcho {
+  std::string key;
+  std::string code;
+  std::chrono::steady_clock::time_point time{};
+  bool valid = false;
+};
+
+inline bool ConsumeImeKeyEcho(ImeKeyEcho* last, int state, const char* key,
+                              const char* code) {
+  if (!last || state != LAUFEY_KEY_PRESSED) {
+    return false;
+  }
+  auto now = std::chrono::steady_clock::now();
+  std::string k = key ? key : "";
+  std::string c = code ? code : "";
+  if (last->valid &&
+      (now - last->time) < std::chrono::milliseconds(40)) {
+    bool same_code =
+        !c.empty() && c != "Unidentified" && c == last->code;
+    bool same_key = !k.empty() && k != "Unidentified" && k == last->key;
+    if (same_code || same_key) {
+      return true;
+    }
+  }
+  last->key = std::move(k);
+  last->code = std::move(c);
+  last->time = now;
+  last->valid = true;
+  return false;
+}
+
+}  // namespace laufey_common
+
+#endif  // LAUFEY_IME_KEY_ECHO_H_

--- a/backend-common/include/laufey_backend_common.h
+++ b/backend-common/include/laufey_backend_common.h
@@ -33,6 +33,18 @@ namespace laufey_common {
 
 std::wstring Utf8ToWide(const std::string& s);
 std::string WideToUtf8(const std::wstring& w);
+
+// Observe IME on a Win32 HWND the same way keyboard events are observed:
+// the engine still owns composition; we forward start/update/end.
+// `hwnd` is the top-level window; Chromium/WebView2 child HWNDs that
+// actually receive WM_IME_* are found and subclassed.
+using ImeNoteFn = void (*)(uint32_t window_id, bool composing,
+                           const std::string& data);
+void InstallWinImeObserver(void* hwnd, uint32_t window_id, ImeNoteFn note);
+void UninstallWinImeObserver(void* hwnd);
+// Handle an IME message already delivered to `hwnd` (parent WndProc).
+void HandleWinImeMessage(void* hwnd, unsigned msg, unsigned long long wparam,
+                         long long lparam, uint32_t window_id, ImeNoteFn note);
 #endif
 
 // ---------------------------------------------------------------------------

--- a/backend-common/src/ime_win.cc
+++ b/backend-common/src/ime_win.cc
@@ -1,0 +1,165 @@
+// Copyright 2025 Divy Srivastava. All rights reserved. MIT license.
+
+#include "laufey_backend_common.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <imm.h>
+
+#include <map>
+#include <mutex>
+#include <string>
+
+#pragma comment(lib, "imm32.lib")
+
+namespace laufey_common {
+namespace {
+
+struct SubclassState {
+  WNDPROC old_proc = nullptr;
+  uint32_t window_id = 0;
+  ImeNoteFn note = nullptr;
+};
+
+std::mutex g_mu;
+std::map<HWND, SubclassState> g_subclasses;
+
+std::string ImmString(HIMC imc, DWORD idx) {
+  LONG bytes = ImmGetCompositionStringW(imc, idx, nullptr, 0);
+  if (bytes <= 0) {
+    return {};
+  }
+  std::wstring w(static_cast<size_t>(bytes) / sizeof(wchar_t), L'\0');
+  ImmGetCompositionStringW(imc, idx, w.data(), bytes);
+  while (!w.empty() && w.back() == L'\0') {
+    w.pop_back();
+  }
+  return WideToUtf8(w);
+}
+
+void HandleImeOnHwnd(HWND hwnd, UINT msg, LPARAM lParam, uint32_t window_id,
+                     ImeNoteFn note) {
+  if (!note) {
+    return;
+  }
+  switch (msg) {
+    case WM_IME_STARTCOMPOSITION:
+      note(window_id, true, {});
+      break;
+    case WM_IME_COMPOSITION: {
+      HIMC imc = ImmGetContext(hwnd);
+      if (!imc) {
+        break;
+      }
+      if (lParam & GCS_RESULTSTR) {
+        note(window_id, false, ImmString(imc, GCS_RESULTSTR));
+      } else if (lParam & GCS_COMPSTR) {
+        note(window_id, true, ImmString(imc, GCS_COMPSTR));
+      }
+      ImmReleaseContext(hwnd, imc);
+      break;
+    }
+    case WM_IME_ENDCOMPOSITION:
+      note(window_id, false, {});
+      break;
+    default:
+      break;
+  }
+}
+
+bool IsImeMessage(UINT msg) {
+  return msg == WM_IME_STARTCOMPOSITION || msg == WM_IME_COMPOSITION ||
+         msg == WM_IME_ENDCOMPOSITION;
+}
+
+LRESULT CALLBACK ImeSubclassProc(HWND hwnd, UINT msg, WPARAM wParam,
+                                 LPARAM lParam) {
+  SubclassState state;
+  {
+    std::lock_guard<std::mutex> lock(g_mu);
+    auto it = g_subclasses.find(hwnd);
+    if (it == g_subclasses.end()) {
+      return DefWindowProcW(hwnd, msg, wParam, lParam);
+    }
+    state = it->second;
+  }
+  if (IsImeMessage(msg)) {
+    HandleImeOnHwnd(hwnd, msg, lParam, state.window_id, state.note);
+  }
+  if (msg == WM_NCDESTROY) {
+    WNDPROC old = state.old_proc;
+    {
+      std::lock_guard<std::mutex> lock(g_mu);
+      g_subclasses.erase(hwnd);
+    }
+    return CallWindowProcW(old, hwnd, msg, wParam, lParam);
+  }
+  return CallWindowProcW(state.old_proc, hwnd, msg, wParam, lParam);
+}
+
+void SubclassHwnd(HWND hwnd, uint32_t window_id, ImeNoteFn note) {
+  if (!hwnd || !note) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(g_mu);
+  if (g_subclasses.count(hwnd)) {
+    g_subclasses[hwnd].window_id = window_id;
+    g_subclasses[hwnd].note = note;
+    return;
+  }
+  SubclassState state;
+  state.window_id = window_id;
+  state.note = note;
+  state.old_proc = reinterpret_cast<WNDPROC>(SetWindowLongPtrW(
+      hwnd, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(ImeSubclassProc)));
+  if (state.old_proc) {
+    g_subclasses[hwnd] = state;
+  }
+}
+
+BOOL CALLBACK EnumChromeChild(HWND hwnd, LPARAM lParam) {
+  wchar_t cls[64] = {};
+  GetClassNameW(hwnd, cls, 64);
+  if (wcsstr(cls, L"Chrome_WidgetWin") ||
+      wcsstr(cls, L"Chrome_RenderWidgetHostHWND") ||
+      wcsstr(cls, L"Intermediate D3D Window")) {
+    auto* ctx = reinterpret_cast<std::pair<uint32_t, ImeNoteFn>*>(lParam);
+    SubclassHwnd(hwnd, ctx->first, ctx->second);
+  }
+  return TRUE;
+}
+
+}  // namespace
+
+void HandleWinImeMessage(void* hwnd, unsigned msg, unsigned long long,
+                         long long lparam, uint32_t window_id, ImeNoteFn note) {
+  HandleImeOnHwnd(static_cast<HWND>(hwnd), static_cast<UINT>(msg),
+                  static_cast<LPARAM>(lparam), window_id, note);
+}
+
+void InstallWinImeObserver(void* hwnd_void, uint32_t window_id,
+                           ImeNoteFn note) {
+  HWND hwnd = static_cast<HWND>(hwnd_void);
+  if (!hwnd || !note) {
+    return;
+  }
+  SubclassHwnd(hwnd, window_id, note);
+  std::pair<uint32_t, ImeNoteFn> ctx{window_id, note};
+  EnumChildWindows(hwnd, EnumChromeChild, reinterpret_cast<LPARAM>(&ctx));
+}
+
+void UninstallWinImeObserver(void* hwnd_void) {
+  HWND hwnd = static_cast<HWND>(hwnd_void);
+  if (!hwnd) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(g_mu);
+  auto it = g_subclasses.find(hwnd);
+  if (it != g_subclasses.end()) {
+    SetWindowLongPtrW(hwnd, GWLP_WNDPROC,
+                      reinterpret_cast<LONG_PTR>(it->second.old_proc));
+    g_subclasses.erase(it);
+  }
+}
+
+}  // namespace laufey_common

--- a/backend-winit-common/src/lib.rs
+++ b/backend-winit-common/src/lib.rs
@@ -33,7 +33,7 @@ use winit::window::{Window, WindowLevel};
 // Bumping this in lockstep with the capi is mandatory: the capi's `init_api`
 // rejects any backend whose reported `version` differs, and the vtable layout
 // below must match the `laufey_backend_api` struct as of this version.
-pub const LAUFEY_API_VERSION: u32 = 34;
+pub const LAUFEY_API_VERSION: u32 = 35;
 
 /// Creation-time window style flags (mirror `LAUFEY_WINDOW_FLAG_*` in laufey.h).
 pub const LAUFEY_WINDOW_FLAG_FRAMELESS: u32 = 1 << 0;
@@ -564,6 +564,12 @@ pub struct LaufeyBackendApi {
     Option<unsafe extern "C" fn(*mut c_void, u32, bool)>,
   pub is_click_passthrough_forward:
     Option<unsafe extern "C" fn(*mut c_void, u32) -> bool>,
+
+  // --- IME (API >= 35) ---
+  // Implemented via winit's `Window::set_ime_allowed` / `set_ime_cursor_area`.
+  pub set_ime_allowed: Option<unsafe extern "C" fn(*mut c_void, u32, bool)>,
+  pub set_ime_cursor_area:
+    Option<unsafe extern "C" fn(*mut c_void, u32, f64, f64, f64, f64)>,
 }
 
 unsafe impl Send for LaufeyBackendApi {}
@@ -1206,6 +1212,9 @@ pub fn create_api_base() -> LaufeyBackendApi {
     // observation API.
     set_click_passthrough_forward: None,
     is_click_passthrough_forward: None,
+    // IME (API >= 35): filled by fill_common_api.
+    set_ime_allowed: None,
+    set_ime_cursor_area: None,
   }
 }
 
@@ -1748,6 +1757,10 @@ pub struct WindowState {
   pub last_press_time: Mutex<Option<std::time::Instant>>,
   pub last_press_button: Mutex<Option<winit::event::MouseButton>>,
   pub click_count: Mutex<i32>,
+  /// Allowed by default so CJK composition matches WebView / CEF.
+  pub ime_allowed: Mutex<bool>,
+  /// Logical client rect last passed to `set_ime_cursor_area`.
+  pub ime_cursor_area: Mutex<Option<(f64, f64, f64, f64)>>,
 }
 
 impl WindowState {
@@ -1768,6 +1781,8 @@ impl WindowState {
       last_press_time: Mutex::new(None),
       last_press_button: Mutex::new(None),
       click_count: Mutex::new(0),
+      ime_allowed: Mutex::new(true),
+      ime_cursor_area: Mutex::new(None),
     }
   }
 }
@@ -1896,6 +1911,12 @@ pub enum CommonEvent {
     window_id: u32,
   },
   ShowContextMenu {
+    window_id: u32,
+  },
+  SetImeAllowed {
+    window_id: u32,
+  },
+  SetImeCursorArea {
     window_id: u32,
   },
   Quit,
@@ -2581,6 +2602,27 @@ macro_rules! define_common_backend_fns {
       }
     }
 
+    unsafe extern "C" fn backend_set_ime_allowed(
+      _data: *mut ::std::ffi::c_void,
+      window_id: u32,
+      allowed: bool,
+    ) {
+      let _ = $crate::request_set_ime_allowed::<$B>(window_id, allowed);
+    }
+
+    unsafe extern "C" fn backend_set_ime_cursor_area(
+      _data: *mut ::std::ffi::c_void,
+      window_id: u32,
+      x: f64,
+      y: f64,
+      width: f64,
+      height: f64,
+    ) {
+      let _ = $crate::request_set_ime_cursor_area::<$B>(
+        window_id, x, y, width, height,
+      );
+    }
+
     unsafe extern "C" fn backend_set_dock_badge(
       _data: *mut ::std::ffi::c_void,
       badge: *const ::std::ffi::c_char,
@@ -2936,6 +2978,8 @@ macro_rules! fill_common_api {
     $api.string_free = Some(backend_string_free);
     $api.set_application_menu = Some(backend_set_application_menu);
     $api.show_context_menu = Some(backend_show_context_menu);
+    $api.set_ime_allowed = Some(backend_set_ime_allowed);
+    $api.set_ime_cursor_area = Some(backend_set_ime_cursor_area);
     $api.set_dock_badge = Some(backend_set_dock_badge);
     $api.bounce_dock = Some(backend_bounce_dock);
     $api.set_dock_menu = Some(backend_set_dock_menu);
@@ -3154,6 +3198,22 @@ pub fn handle_common_event<B: BackendAccess>(
       }
       true
     }
+    CommonEvent::SetImeAllowed { window_id: eid } if *eid == window_id => {
+      if let Some(state) = B::get() {
+        state.common().with_window(window_id, |ws| {
+          apply_ime_state(window, ws);
+        });
+      }
+      true
+    }
+    CommonEvent::SetImeCursorArea { window_id: eid } if *eid == window_id => {
+      if let Some(state) = B::get() {
+        state.common().with_window(window_id, |ws| {
+          apply_ime_cursor_area(window, ws);
+        });
+      }
+      true
+    }
     CommonEvent::UiTask { task, data } => {
       unsafe { task(*data as *mut c_void) };
       true
@@ -3161,6 +3221,80 @@ pub fn handle_common_event<B: BackendAccess>(
     CommonEvent::Quit => false, // caller handles exit
     _ => false,
   }
+}
+
+pub fn request_set_ime_allowed<B: BackendAccess>(
+  window_id: u32,
+  allowed: bool,
+) -> bool {
+  let Some(state) = B::get() else {
+    return false;
+  };
+  if state
+    .common()
+    .with_window(window_id, |ws| {
+      *ws.ime_allowed.lock().unwrap() = allowed;
+    })
+    .is_none()
+  {
+    return false;
+  }
+  let _ = state
+    .proxy()
+    .send_event(B::common_event(CommonEvent::SetImeAllowed { window_id }));
+  true
+}
+
+pub fn request_set_ime_cursor_area<B: BackendAccess>(
+  window_id: u32,
+  x: f64,
+  y: f64,
+  width: f64,
+  height: f64,
+) -> bool {
+  let Some(state) = B::get() else {
+    return false;
+  };
+  if state
+    .common()
+    .with_window(window_id, |ws| {
+      *ws.ime_cursor_area.lock().unwrap() = Some((x, y, width, height));
+    })
+    .is_none()
+  {
+    return false;
+  }
+  let _ = state
+    .proxy()
+    .send_event(B::common_event(CommonEvent::SetImeCursorArea { window_id }));
+  true
+}
+
+pub fn apply_ime_state(window: &Window, ws: &WindowState) {
+  let allowed = *ws.ime_allowed.lock().unwrap();
+  window.set_ime_allowed(allowed);
+  if allowed {
+    apply_ime_cursor_area(window, ws);
+  }
+}
+
+pub fn apply_ime_cursor_area(window: &Window, ws: &WindowState) {
+  if !*ws.ime_allowed.lock().unwrap() {
+    return;
+  }
+  let (x, y, w, h) = match *ws.ime_cursor_area.lock().unwrap() {
+    Some(rect) => rect,
+    None => {
+      let physical = window.inner_size();
+      let logical = physical.to_logical::<f64>(window.scale_factor());
+      (0.0, 0.0, logical.width, logical.height)
+    }
+  };
+  if w <= 0.0 || h <= 0.0 {
+    return;
+  }
+  window
+    .set_ime_cursor_area(LogicalPosition::new(x, y), LogicalSize::new(w, h));
 }
 
 /// Apply pending state to window attributes before creation.
@@ -3224,6 +3358,7 @@ pub fn apply_pending_post_create(ws: &WindowState, window: &Window) {
   if *ws.pending_flags.lock().unwrap() & LAUFEY_WINDOW_FLAG_NO_ACTIVATE != 0 {
     window.set_window_level(WindowLevel::AlwaysOnTop);
   }
+  apply_ime_state(window, ws);
 }
 
 // --- Native dialog implementation ---

--- a/backend-winit-common/src/lib.rs
+++ b/backend-winit-common/src/lib.rs
@@ -76,6 +76,12 @@ pub type LaufeyKeyboardEventFn = unsafe extern "C" fn(
   u32,           // modifiers
   bool,          // repeat
 );
+pub type LaufeyImeEventFn = unsafe extern "C" fn(
+  *mut c_void,   // user_data
+  u32,           // window_id
+  c_int,         // type (0=start, 1=update, 2=end)
+  *const c_char, // data
+);
 pub type LaufeyMouseMoveFn = unsafe extern "C" fn(
   *mut c_void, // user_data
   u32,         // window_id
@@ -570,6 +576,9 @@ pub struct LaufeyBackendApi {
   pub set_ime_allowed: Option<unsafe extern "C" fn(*mut c_void, u32, bool)>,
   pub set_ime_cursor_area:
     Option<unsafe extern "C" fn(*mut c_void, u32, f64, f64, f64, f64)>,
+  pub set_ime_event_handler: Option<
+    unsafe extern "C" fn(*mut c_void, Option<LaufeyImeEventFn>, *mut c_void),
+  >,
 }
 
 unsafe impl Send for LaufeyBackendApi {}
@@ -1215,6 +1224,7 @@ pub fn create_api_base() -> LaufeyBackendApi {
     // IME (API >= 35): filled by fill_common_api.
     set_ime_allowed: None,
     set_ime_cursor_area: None,
+    set_ime_event_handler: None,
   }
 }
 
@@ -1761,6 +1771,10 @@ pub struct WindowState {
   pub ime_allowed: Mutex<bool>,
   /// Logical client rect last passed to `set_ime_cursor_area`.
   pub ime_cursor_area: Mutex<Option<(f64, f64, f64, f64)>>,
+  /// True between the first `Preedit`/`Commit` and the matching `Commit` or
+  /// `Disabled`. Used so we emit a single compositionstart and so
+  /// `Disabled` can cancel an in-flight session.
+  pub ime_composing: Mutex<bool>,
 }
 
 impl WindowState {
@@ -1783,6 +1797,7 @@ impl WindowState {
       click_count: Mutex::new(0),
       ime_allowed: Mutex::new(false),
       ime_cursor_area: Mutex::new(None),
+      ime_composing: Mutex::new(false),
     }
   }
 }
@@ -1797,6 +1812,7 @@ impl Default for WindowState {
 
 pub struct EventHandlers {
   pub keyboard_handler: Mutex<Option<(LaufeyKeyboardEventFn, usize)>>,
+  pub ime_handler: Mutex<Option<(LaufeyImeEventFn, usize)>>,
   pub mouse_click_handler: Mutex<Option<(LaufeyMouseClickFn, usize)>>,
   pub mouse_move_handler: Mutex<Option<(LaufeyMouseMoveFn, usize)>>,
   pub wheel_handler: Mutex<Option<(LaufeyWheelFn, usize)>>,
@@ -1812,6 +1828,7 @@ impl EventHandlers {
   pub fn new() -> Self {
     Self {
       keyboard_handler: Mutex::new(None),
+      ime_handler: Mutex::new(None),
       mouse_click_handler: Mutex::new(None),
       mouse_move_handler: Mutex::new(None),
       wheel_handler: Mutex::new(None),
@@ -2313,6 +2330,17 @@ macro_rules! define_common_backend_fns {
     ) {
       if let Some(state) = <$B as $crate::BackendAccess>::get() {
         *state.common().handlers.keyboard_handler.lock().unwrap() =
+          handler.map(|h| (h, user_data as usize));
+      }
+    }
+
+    unsafe extern "C" fn backend_set_ime_event_handler(
+      _data: *mut ::std::ffi::c_void,
+      handler: Option<$crate::LaufeyImeEventFn>,
+      user_data: *mut ::std::ffi::c_void,
+    ) {
+      if let Some(state) = <$B as $crate::BackendAccess>::get() {
+        *state.common().handlers.ime_handler.lock().unwrap() =
           handler.map(|h| (h, user_data as usize));
       }
     }
@@ -2964,6 +2992,7 @@ macro_rules! fill_common_api {
     $api.get_display_handle = Some($crate::backend_get_display_handle);
     $api.get_window_handle_type = Some($crate::backend_get_window_handle_type);
     $api.set_keyboard_event_handler = Some(backend_set_keyboard_event_handler);
+    $api.set_ime_event_handler = Some(backend_set_ime_event_handler);
     $api.set_mouse_click_handler = Some(backend_set_mouse_click_handler);
     $api.set_mouse_move_handler = Some(backend_set_mouse_move_handler);
     $api.set_wheel_handler = Some(backend_set_wheel_handler);
@@ -3606,6 +3635,10 @@ pub const LAUFEY_MOD_META: u32 = 1 << 3;
 pub const LAUFEY_KEY_PRESSED: c_int = 0;
 pub const LAUFEY_KEY_RELEASED: c_int = 1;
 
+pub const LAUFEY_IME_START: c_int = 0;
+pub const LAUFEY_IME_UPDATE: c_int = 1;
+pub const LAUFEY_IME_END: c_int = 2;
+
 pub const LAUFEY_MOUSE_BUTTON_LEFT: c_int = 0;
 pub const LAUFEY_MOUSE_BUTTON_RIGHT: c_int = 1;
 pub const LAUFEY_MOUSE_BUTTON_MIDDLE: c_int = 2;
@@ -3654,6 +3687,74 @@ pub fn winit_code_to_string(physical: &winit::keyboard::PhysicalKey) -> String {
   match physical {
     winit::keyboard::PhysicalKey::Code(code) => format!("{code:?}"),
     winit::keyboard::PhysicalKey::Unidentified(_) => "Unidentified".to_string(),
+  }
+}
+
+/// Translate a winit `Ime` event into zero or more (type, data) pairs and
+/// the resulting composing flag. `Enabled` is a capability signal, not a
+/// composition session — `compositionstart` fires on the first `Preedit`
+/// or `Commit`.
+pub fn ime_to_events(
+  ime: &winit::event::Ime,
+  composing: bool,
+) -> (Vec<(c_int, String)>, bool) {
+  match ime {
+    winit::event::Ime::Enabled => (vec![], composing),
+    winit::event::Ime::Preedit(text, _) => {
+      let mut events = Vec::new();
+      let mut now = composing;
+      if !now {
+        events.push((LAUFEY_IME_START, String::new()));
+        now = true;
+      }
+      events.push((LAUFEY_IME_UPDATE, text.clone()));
+      (events, now)
+    }
+    winit::event::Ime::Commit(text) => {
+      let mut events = Vec::new();
+      if !composing {
+        events.push((LAUFEY_IME_START, String::new()));
+      }
+      events.push((LAUFEY_IME_END, text.clone()));
+      (events, false)
+    }
+    winit::event::Ime::Disabled => {
+      if composing {
+        (vec![(LAUFEY_IME_END, String::new())], false)
+      } else {
+        (vec![], false)
+      }
+    }
+  }
+}
+
+fn fire_ime_event(
+  handlers: &EventHandlers,
+  window_id: u32,
+  ty: c_int,
+  data: &str,
+) {
+  let handler = handlers.ime_handler.lock().unwrap();
+  if let Some((cb, user_data)) = *handler {
+    let c_data = CString::new(data).unwrap_or_default();
+    unsafe {
+      cb(user_data as *mut c_void, window_id, ty, c_data.as_ptr());
+    }
+  }
+}
+
+/// Dispatch a winit IME event as W3C composition events.
+pub fn dispatch_ime_event(
+  handlers: &EventHandlers,
+  ws: &WindowState,
+  window_id: u32,
+  ime: &winit::event::Ime,
+) {
+  let composing = *ws.ime_composing.lock().unwrap();
+  let (events, now_composing) = ime_to_events(ime, composing);
+  *ws.ime_composing.lock().unwrap() = now_composing;
+  for (ty, data) in events {
+    fire_ime_event(handlers, window_id, ty, &data);
   }
 }
 
@@ -4031,5 +4132,77 @@ pub fn load_and_start_runtime(api: LaufeyBackendApi) {
       println!("No runtime library found. Set LAUFEY_RUNTIME_PATH or place libruntime in current directory.");
       println!("Starting without runtime integration...");
     }
+  }
+}
+
+#[cfg(test)]
+mod ime_tests {
+  use super::*;
+  use winit::event::Ime;
+
+  fn types_of(ime: Ime, composing: bool) -> (Vec<c_int>, bool) {
+    let (events, now) = ime_to_events(&ime, composing);
+    (events.into_iter().map(|(ty, _)| ty).collect(), now)
+  }
+
+  #[test]
+  fn enabled_is_not_a_composition_session() {
+    let (types, now) = types_of(Ime::Enabled, false);
+    assert!(types.is_empty());
+    assert!(!now);
+  }
+
+  #[test]
+  fn first_preedit_starts_then_updates() {
+    let (events, now) = ime_to_events(&Ime::Preedit("あ".into(), None), false);
+    assert_eq!(
+      events,
+      vec![
+        (LAUFEY_IME_START, String::new()),
+        (LAUFEY_IME_UPDATE, "あ".into()),
+      ]
+    );
+    assert!(now);
+  }
+
+  #[test]
+  fn subsequent_preedit_is_update_only() {
+    let (events, now) = ime_to_events(&Ime::Preedit("あい".into(), None), true);
+    assert_eq!(events, vec![(LAUFEY_IME_UPDATE, "あい".into())]);
+    assert!(now);
+  }
+
+  #[test]
+  fn commit_while_composing_ends() {
+    let (events, now) = ime_to_events(&Ime::Commit("愛".into()), true);
+    assert_eq!(events, vec![(LAUFEY_IME_END, "愛".into())]);
+    assert!(!now);
+  }
+
+  #[test]
+  fn commit_without_preedit_starts_then_ends() {
+    let (events, now) = ime_to_events(&Ime::Commit("a".into()), false);
+    assert_eq!(
+      events,
+      vec![
+        (LAUFEY_IME_START, String::new()),
+        (LAUFEY_IME_END, "a".into()),
+      ]
+    );
+    assert!(!now);
+  }
+
+  #[test]
+  fn disabled_cancels_an_open_session() {
+    let (events, now) = ime_to_events(&Ime::Disabled, true);
+    assert_eq!(events, vec![(LAUFEY_IME_END, String::new())]);
+    assert!(!now);
+  }
+
+  #[test]
+  fn disabled_without_session_is_silent() {
+    let (types, now) = types_of(Ime::Disabled, false);
+    assert!(types.is_empty());
+    assert!(!now);
   }
 }

--- a/backend-winit-common/src/lib.rs
+++ b/backend-winit-common/src/lib.rs
@@ -1757,7 +1757,7 @@ pub struct WindowState {
   pub last_press_time: Mutex<Option<std::time::Instant>>,
   pub last_press_button: Mutex<Option<winit::event::MouseButton>>,
   pub click_count: Mutex<i32>,
-  /// Allowed by default so CJK composition matches WebView / CEF.
+  /// Off by default (winit's default). Call `set_ime_allowed(true)` for CJK.
   pub ime_allowed: Mutex<bool>,
   /// Logical client rect last passed to `set_ime_cursor_area`.
   pub ime_cursor_area: Mutex<Option<(f64, f64, f64, f64)>>,
@@ -1781,7 +1781,7 @@ impl WindowState {
       last_press_time: Mutex::new(None),
       last_press_button: Mutex::new(None),
       click_count: Mutex::new(0),
-      ime_allowed: Mutex::new(true),
+      ime_allowed: Mutex::new(false),
       ime_cursor_area: Mutex::new(None),
     }
   }

--- a/backend-winit-common/src/lib.rs
+++ b/backend-winit-common/src/lib.rs
@@ -1775,6 +1775,9 @@ pub struct WindowState {
   /// `Disabled`. Used so we emit a single compositionstart and so
   /// `Disabled` can cancel an in-flight session.
   pub ime_composing: Mutex<bool>,
+  /// Last keydown used to drop the extra press Japanese IMEs (e.g. Google
+  /// ひらがな) post for the same physical key.
+  pub last_key_echo: Mutex<Option<(String, String, std::time::Instant)>>,
 }
 
 impl WindowState {
@@ -1798,6 +1801,7 @@ impl WindowState {
       ime_allowed: Mutex::new(false),
       ime_cursor_area: Mutex::new(None),
       ime_composing: Mutex::new(false),
+      last_key_echo: Mutex::new(None),
     }
   }
 }
@@ -3758,9 +3762,41 @@ pub fn dispatch_ime_event(
   }
 }
 
+/// Google 日本語 IME (and similar) posts a second keyDown for the same
+/// physical key a few milliseconds after the first while the menu bar
+/// shows ひらがな. Drop that echo so the runtime sees one `keydown`.
+pub const IME_KEY_ECHO_WINDOW: std::time::Duration =
+  std::time::Duration::from_millis(40);
+
+pub fn is_ime_key_echo(
+  last: &mut Option<(String, String, std::time::Instant)>,
+  pressed: bool,
+  key: &str,
+  code: &str,
+  now: std::time::Instant,
+) -> bool {
+  if !pressed {
+    return false;
+  }
+  if let Some((prev_key, prev_code, t)) = last.as_ref() {
+    if now.duration_since(*t) < IME_KEY_ECHO_WINDOW {
+      let same_code =
+        !code.is_empty() && code != "Unidentified" && code == prev_code;
+      let same_key =
+        !key.is_empty() && key != "Unidentified" && key == prev_key;
+      if same_code || same_key {
+        return true;
+      }
+    }
+  }
+  *last = Some((key.to_string(), code.to_string(), now));
+  false
+}
+
 /// Dispatch a keyboard event to the registered handler.
 pub fn dispatch_keyboard_event(
   handlers: &EventHandlers,
+  ws: &WindowState,
   window_id: u32,
   key_event: &winit::event::KeyEvent,
   modifiers: winit::keyboard::ModifiersState,
@@ -3773,6 +3809,15 @@ pub fn dispatch_keyboard_event(
     };
     let key_str = winit_key_to_string(&key_event.logical_key);
     let code_str = winit_code_to_string(&key_event.physical_key);
+    if is_ime_key_echo(
+      &mut ws.last_key_echo.lock().unwrap(),
+      state == LAUFEY_KEY_PRESSED,
+      &key_str,
+      &code_str,
+      std::time::Instant::now(),
+    ) {
+      return;
+    }
     let mods = modifiers_to_laufey(modifiers);
 
     let c_key = std::ffi::CString::new(key_str).unwrap_or_default();
@@ -4197,6 +4242,42 @@ mod ime_tests {
     let (events, now) = ime_to_events(&Ime::Disabled, true);
     assert_eq!(events, vec![(LAUFEY_IME_END, String::new())]);
     assert!(!now);
+  }
+
+  #[test]
+  fn ime_key_echo_drops_the_second_a() {
+    let mut last = None;
+    let t0 = std::time::Instant::now();
+    assert!(!is_ime_key_echo(&mut last, true, "a", "KeyA", t0));
+    assert!(is_ime_key_echo(
+      &mut last,
+      true,
+      "a",
+      "KeyA",
+      t0 + std::time::Duration::from_millis(5),
+    ));
+  }
+
+  #[test]
+  fn ime_key_echo_keeps_a_later_real_press() {
+    let mut last = None;
+    let t0 = std::time::Instant::now();
+    assert!(!is_ime_key_echo(&mut last, true, "a", "KeyA", t0));
+    assert!(!is_ime_key_echo(
+      &mut last,
+      true,
+      "a",
+      "KeyA",
+      t0 + std::time::Duration::from_millis(80),
+    ));
+  }
+
+  #[test]
+  fn ime_key_echo_keeps_a_different_key() {
+    let mut last = None;
+    let t0 = std::time::Instant::now();
+    assert!(!is_ime_key_echo(&mut last, true, "a", "KeyA", t0));
+    assert!(!is_ime_key_echo(&mut last, true, "i", "KeyI", t0));
   }
 
   #[test]

--- a/backend-winit-common/src/lib.rs
+++ b/backend-winit-common/src/lib.rs
@@ -1777,7 +1777,9 @@ pub struct WindowState {
   pub ime_composing: Mutex<bool>,
   /// Last keydown used to drop the extra press Japanese IMEs (e.g. Google
   /// ひらがな) post for the same physical key.
-  pub last_key_echo: Mutex<Option<(String, String, std::time::Instant)>>,
+  /// `code` and time of the key press that has not been released yet, used to
+  /// spot an IME's duplicate keydown. See [`is_ime_key_echo`].
+  pub last_key_echo: Mutex<Option<(String, std::time::Instant)>>,
 }
 
 impl WindowState {
@@ -3768,28 +3770,43 @@ pub fn dispatch_ime_event(
 pub const IME_KEY_ECHO_WINDOW: std::time::Duration =
   std::time::Duration::from_millis(40);
 
+/// `last` holds the press that has not been released yet, so a press can only
+/// be judged an echo of one still physically down.
 pub fn is_ime_key_echo(
-  last: &mut Option<(String, String, std::time::Instant)>,
+  last: &mut Option<(String, std::time::Instant)>,
   pressed: bool,
-  key: &str,
+  repeat: bool,
   code: &str,
   now: std::time::Instant,
 ) -> bool {
   if !pressed {
+    // A release ends that key's press. Whatever comes next for it is a real
+    // second press, not a duplicate of the first — typing "nn" (ん) faster
+    // than the window would otherwise lose the second n.
+    if last.as_ref().is_some_and(|(prev, _)| prev == code) {
+      *last = None;
+    }
     return false;
   }
-  if let Some((prev_key, prev_code, t)) = last.as_ref() {
-    if now.duration_since(*t) < IME_KEY_ECHO_WINDOW {
-      let same_code =
-        !code.is_empty() && code != "Unidentified" && code == prev_code;
-      let same_key =
-        !key.is_empty() && key != "Unidentified" && key == prev_key;
-      if same_code || same_key {
-        return true;
-      }
+  // Auto-repeat is a legitimate stream of presses with no release between
+  // them. Windows' fastest repeat rate is ~33ms, inside the window, so
+  // filtering here silently drops half of every held key.
+  if repeat {
+    return false;
+  }
+  // Only the same physical key can be an echo, so match on `code` alone.
+  // Matching the logical `key` collapses distinct keys: every key the IME
+  // consumes reports "Process", which is exactly when this runs.
+  if let Some((prev_code, t)) = last.as_ref() {
+    if now.duration_since(*t) < IME_KEY_ECHO_WINDOW
+      && !code.is_empty()
+      && code != "Unidentified"
+      && code == prev_code
+    {
+      return true;
     }
   }
-  *last = Some((key.to_string(), code.to_string(), now));
+  *last = Some((code.to_string(), now));
   false
 }
 
@@ -3812,7 +3829,7 @@ pub fn dispatch_keyboard_event(
     if is_ime_key_echo(
       &mut ws.last_key_echo.lock().unwrap(),
       state == LAUFEY_KEY_PRESSED,
-      &key_str,
+      key_event.repeat,
       &code_str,
       std::time::Instant::now(),
     ) {
@@ -4248,11 +4265,11 @@ mod ime_tests {
   fn ime_key_echo_drops_the_second_a() {
     let mut last = None;
     let t0 = std::time::Instant::now();
-    assert!(!is_ime_key_echo(&mut last, true, "a", "KeyA", t0));
+    assert!(!is_ime_key_echo(&mut last, true, false, "KeyA", t0));
     assert!(is_ime_key_echo(
       &mut last,
       true,
-      "a",
+      false,
       "KeyA",
       t0 + std::time::Duration::from_millis(5),
     ));
@@ -4262,11 +4279,11 @@ mod ime_tests {
   fn ime_key_echo_keeps_a_later_real_press() {
     let mut last = None;
     let t0 = std::time::Instant::now();
-    assert!(!is_ime_key_echo(&mut last, true, "a", "KeyA", t0));
+    assert!(!is_ime_key_echo(&mut last, true, false, "KeyA", t0));
     assert!(!is_ime_key_echo(
       &mut last,
       true,
-      "a",
+      false,
       "KeyA",
       t0 + std::time::Duration::from_millis(80),
     ));
@@ -4276,8 +4293,78 @@ mod ime_tests {
   fn ime_key_echo_keeps_a_different_key() {
     let mut last = None;
     let t0 = std::time::Instant::now();
-    assert!(!is_ime_key_echo(&mut last, true, "a", "KeyA", t0));
-    assert!(!is_ime_key_echo(&mut last, true, "i", "KeyI", t0));
+    assert!(!is_ime_key_echo(&mut last, true, false, "KeyA", t0));
+    assert!(!is_ime_key_echo(&mut last, true, false, "KeyI", t0));
+  }
+
+  #[test]
+  fn ime_key_echo_keeps_auto_repeat() {
+    // Windows' fastest repeat rate is ~33ms, inside the 40ms window. Measured
+    // on a 150% display box with KeyboardSpeed=31, filtering repeats here
+    // delivered 5 of 10 held-key presses.
+    let mut last = None;
+    let t0 = std::time::Instant::now();
+    assert!(!is_ime_key_echo(&mut last, true, false, "KeyA", t0));
+    for i in 1..10 {
+      let t = t0 + std::time::Duration::from_millis(33 * i);
+      assert!(
+        !is_ime_key_echo(&mut last, true, true, "KeyA", t),
+        "auto-repeat #{i} was dropped"
+      );
+    }
+  }
+
+  #[test]
+  fn ime_key_echo_keeps_a_press_after_release() {
+    // "nn" (ん) typed faster than the window: the release proves the second
+    // press is real.
+    let mut last = None;
+    let t0 = std::time::Instant::now();
+    assert!(!is_ime_key_echo(&mut last, true, false, "KeyN", t0));
+    assert!(!is_ime_key_echo(
+      &mut last,
+      false,
+      false,
+      "KeyN",
+      t0 + std::time::Duration::from_millis(5),
+    ));
+    assert!(!is_ime_key_echo(
+      &mut last,
+      true,
+      false,
+      "KeyN",
+      t0 + std::time::Duration::from_millis(10),
+    ));
+  }
+
+  #[test]
+  fn ime_key_echo_keeps_distinct_keys_during_composition() {
+    // Every key the IME consumes reports `key` as "Process", so matching the
+    // logical key collapsed distinct presses. Typing "nihongo" at speed lost
+    // the h and o presses before this matched on `code` alone.
+    let mut last = None;
+    let t0 = std::time::Instant::now();
+    let t = |ms| t0 + std::time::Duration::from_millis(ms);
+    assert!(!is_ime_key_echo(&mut last, true, false, "KeyN", t(0)));
+    assert!(!is_ime_key_echo(&mut last, false, false, "KeyN", t(5)));
+    assert!(!is_ime_key_echo(&mut last, true, false, "KeyI", t(10)));
+    assert!(!is_ime_key_echo(&mut last, false, false, "KeyI", t(15)));
+    assert!(!is_ime_key_echo(&mut last, true, false, "KeyH", t(20)));
+  }
+
+  #[test]
+  fn ime_key_echo_ignores_unidentified_codes() {
+    // Synthetic unicode input reports no usable physical key; never guess.
+    let mut last = None;
+    let t0 = std::time::Instant::now();
+    assert!(!is_ime_key_echo(&mut last, true, false, "Unidentified", t0));
+    assert!(!is_ime_key_echo(
+      &mut last,
+      true,
+      false,
+      "Unidentified",
+      t0 + std::time::Duration::from_millis(5),
+    ));
   }
 
   #[test]

--- a/capi/include/laufey.h
+++ b/capi/include/laufey.h
@@ -860,16 +860,17 @@ struct laufey_backend_api {
   //
   // Allow or deny IME on the window. Off by default (matches winit); pass
   // true when a text field is focused so CJK composition can start. A live
-  // setter that can be toggled at any time. WebView and CEF leave this a
-  // no-op — the engine owns composition. NULL on backends older than API
-  // version 35; callers must null-check.
+  // setter that can be toggled at any time. Raw/winit only. WebView and CEF
+  // leave this NULL — the engine owns composition. NULL on backends older
+  // than API version 35; callers must null-check.
   void (*set_ime_allowed)(void* backend_data, uint32_t window_id,
                           bool allowed);
 
   // Logical, top-left client rectangle the IME candidate window should sit
   // next to and not obscure (typically the caret or an in-window field; it
-  // need not stay inside the window). WebView and CEF leave this a no-op.
-  // NULL on backends older than API version 35; callers must null-check.
+  // need not stay inside the window). Raw/winit only. WebView and CEF leave
+  // this NULL. NULL on backends older than API version 35; callers must
+  // null-check.
   void (*set_ime_cursor_area)(void* backend_data, uint32_t window_id, double x,
                               double y, double width, double height);
 

--- a/capi/include/laufey.h
+++ b/capi/include/laufey.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-#define LAUFEY_API_VERSION 34
+#define LAUFEY_API_VERSION 35
 
 // Window handle types for get_window_handle_type
 #define LAUFEY_WINDOW_HANDLE_UNKNOWN 0
@@ -841,6 +841,23 @@ struct laufey_backend_api {
   // false if the id is unknown or the backend doesn't support forwarding.
   // NULL on backends older than API version 34.
   bool (*is_click_passthrough_forward)(void* backend_data, uint32_t window_id);
+
+  // --- IME (API >= 35) -------------------------------------------------------
+  //
+  // Allow or deny IME on the window. Allowed by default so CJK composition
+  // works the same as on WebView / CEF. Pass false to opt out (games that
+  // want raw keys). A live setter that can be toggled at any time. WebView
+  // and CEF leave this a no-op — the engine owns composition. NULL on
+  // backends older than API version 35; callers must null-check.
+  void (*set_ime_allowed)(void* backend_data, uint32_t window_id,
+                          bool allowed);
+
+  // Logical, top-left client rectangle the IME candidate window should sit
+  // next to and not obscure (typically the caret or an in-window field; it
+  // need not stay inside the window). WebView and CEF leave this a no-op.
+  // NULL on backends older than API version 35; callers must null-check.
+  void (*set_ime_cursor_area)(void* backend_data, uint32_t window_id, double x,
+                              double y, double width, double height);
 };
 
 #ifdef __cplusplus

--- a/capi/include/laufey.h
+++ b/capi/include/laufey.h
@@ -875,8 +875,12 @@ struct laufey_backend_api {
                               double y, double width, double height);
 
   // Register a handler for IME composition events (global, receives
-  // window_id in the callback). Raw/winit only. NULL on backends older
-  // than API version 35 and on WebView / CEF; callers must null-check.
+  // window_id in the callback). Observed the same way as keyboard events:
+  // the engine still owns composition; the handler is notified, the event
+  // is not consumed. Raw/winit implements this via winit IME. WebView and
+  // CEF observe the platform IM (NSTextInputClient / WM_IME_* /
+  // WebKitInputMethodContext). CEF on Linux currently has no observer.
+  // NULL on backends older than API version 35; callers must null-check.
   void (*set_ime_event_handler)(void* backend_data,
                                 laufey_ime_event_fn handler, void* user_data);
 };

--- a/capi/include/laufey.h
+++ b/capi/include/laufey.h
@@ -99,6 +99,12 @@ typedef void (*laufey_menu_click_fn)(void* user_data, uint32_t window_id,
 #define LAUFEY_KEY_PRESSED 0
 #define LAUFEY_KEY_RELEASED 1
 
+// IME composition event type (API >= 35). Maps onto the W3C composition
+// event sequence: start → one or more updates → end.
+#define LAUFEY_IME_START 0
+#define LAUFEY_IME_UPDATE 1
+#define LAUFEY_IME_END 2
+
 // Keyboard modifier flags (bitmask)
 #define LAUFEY_MOD_SHIFT (1 << 0)
 #define LAUFEY_MOD_CONTROL (1 << 1)
@@ -251,6 +257,14 @@ typedef void (*laufey_keyboard_event_fn)(
         code,  // physical key code (W3C UI Events code, e.g. "KeyA", "Enter")
     uint32_t modifiers,  // bitmask of LAUFEY_MOD_* flags
     bool repeat);
+
+// Callback for IME composition events (API >= 35). `type` is
+// LAUFEY_IME_START / UPDATE / END. `data` is the current composition
+// string (empty on start, and empty on end when the session is
+// cancelled). Raw/winit only; WebView and CEF leave the setter NULL
+// because the engine owns composition.
+typedef void (*laufey_ime_event_fn)(void* user_data, uint32_t window_id,
+                                    int type, const char* data);
 
 // Callback for window close requested events. Registering this handler
 // (API >= 31) makes the backend WAIT: the window does not close on its own
@@ -858,6 +872,12 @@ struct laufey_backend_api {
   // NULL on backends older than API version 35; callers must null-check.
   void (*set_ime_cursor_area)(void* backend_data, uint32_t window_id, double x,
                               double y, double width, double height);
+
+  // Register a handler for IME composition events (global, receives
+  // window_id in the callback). Raw/winit only. NULL on backends older
+  // than API version 35 and on WebView / CEF; callers must null-check.
+  void (*set_ime_event_handler)(void* backend_data,
+                                laufey_ime_event_fn handler, void* user_data);
 };
 
 #ifdef __cplusplus

--- a/capi/include/laufey.h
+++ b/capi/include/laufey.h
@@ -844,11 +844,11 @@ struct laufey_backend_api {
 
   // --- IME (API >= 35) -------------------------------------------------------
   //
-  // Allow or deny IME on the window. Allowed by default so CJK composition
-  // works the same as on WebView / CEF. Pass false to opt out (games that
-  // want raw keys). A live setter that can be toggled at any time. WebView
-  // and CEF leave this a no-op — the engine owns composition. NULL on
-  // backends older than API version 35; callers must null-check.
+  // Allow or deny IME on the window. Off by default (matches winit); pass
+  // true when a text field is focused so CJK composition can start. A live
+  // setter that can be toggled at any time. WebView and CEF leave this a
+  // no-op — the engine owns composition. NULL on backends older than API
+  // version 35; callers must null-check.
   void (*set_ime_allowed)(void* backend_data, uint32_t window_id,
                           bool allowed);
 

--- a/capi/src/ime.rs
+++ b/capi/src/ime.rs
@@ -1,0 +1,133 @@
+// Copyright 2025 Divy Srivastava. All rights reserved. MIT license.
+
+use std::collections::HashMap;
+use std::ffi::{c_char, c_int, c_void, CStr};
+use std::sync::{Mutex, OnceLock};
+
+use crate::{api, LAUFEY_IME_START, LAUFEY_IME_UPDATE};
+
+#[derive(Debug, Clone)]
+pub struct ImeEvent {
+  pub window_id: u32,
+  pub state: ImeState,
+  pub data: String,
+}
+
+/// Maps onto the W3C `compositionstart` / `compositionupdate` /
+/// `compositionend` sequence. `data` is the current composition string
+/// (empty on start, and empty on end when the session is cancelled).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImeState {
+  Start,
+  Update,
+  End,
+}
+
+impl ImeState {
+  pub(crate) fn from_raw(raw: c_int) -> Self {
+    if raw == LAUFEY_IME_START {
+      Self::Start
+    } else if raw == LAUFEY_IME_UPDATE {
+      Self::Update
+    } else {
+      Self::End
+    }
+  }
+}
+
+static IME_HANDLERS: OnceLock<
+  Mutex<HashMap<u32, Box<dyn Fn(ImeEvent) + Send + Sync>>>,
+> = OnceLock::new();
+
+fn ime_handlers_store(
+) -> &'static Mutex<HashMap<u32, Box<dyn Fn(ImeEvent) + Send + Sync>>> {
+  IME_HANDLERS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+static HANDLER_REGISTERED: std::sync::atomic::AtomicBool =
+  std::sync::atomic::AtomicBool::new(false);
+
+fn ensure_ime_handler_registered() {
+  if !HANDLER_REGISTERED.swap(true, std::sync::atomic::Ordering::SeqCst) {
+    let api = api();
+    if let Some(set_handler) = api.set_ime_event_handler {
+      unsafe {
+        set_handler(
+          api.backend_data,
+          Some(ime_event_trampoline),
+          std::ptr::null_mut(),
+        );
+      }
+    }
+  }
+}
+
+unsafe extern "C" fn ime_event_trampoline(
+  _user_data: *mut c_void,
+  window_id: u32,
+  state: c_int,
+  data: *const c_char,
+) {
+  let data_str = if data.is_null() {
+    String::new()
+  } else {
+    CStr::from_ptr(data).to_string_lossy().into_owned()
+  };
+
+  let event = ImeEvent {
+    window_id,
+    state: ImeState::from_raw(state),
+    data: data_str,
+  };
+
+  let guard = ime_handlers_store().lock().unwrap();
+  if let Some(handler) = guard.get(&window_id) {
+    handler(event);
+  }
+}
+
+/// Register a handler for IME composition events on a specific window.
+/// Raw/winit only; no-op on backends where the engine owns composition.
+pub fn on_ime_event<F>(window_id: u32, handler: F)
+where
+  F: Fn(ImeEvent) + Send + Sync + 'static,
+{
+  ensure_ime_handler_registered();
+  ime_handlers_store()
+    .lock()
+    .unwrap()
+    .insert(window_id, Box::new(handler));
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::LAUFEY_IME_END;
+
+  #[test]
+  fn ime_state_from_raw_known_values() {
+    assert_eq!(ImeState::from_raw(LAUFEY_IME_START), ImeState::Start);
+    assert_eq!(ImeState::from_raw(LAUFEY_IME_UPDATE), ImeState::Update);
+    assert_eq!(ImeState::from_raw(LAUFEY_IME_END), ImeState::End);
+  }
+
+  #[test]
+  fn ime_state_unknown_defaults_to_end() {
+    // The trampoline collapses unknown raw values to End — pinning so a
+    // future extra state can't be misread as Start or Update.
+    assert_eq!(ImeState::from_raw(42), ImeState::End);
+    assert_eq!(ImeState::from_raw(-1), ImeState::End);
+  }
+
+  #[test]
+  fn ime_event_field_passthrough() {
+    let ev = ImeEvent {
+      window_id: 7,
+      state: ImeState::Update,
+      data: "あ".to_string(),
+    };
+    assert_eq!(ev.window_id, 7);
+    assert_eq!(ev.state, ImeState::Update);
+    assert_eq!(ev.data, "あ");
+  }
+}

--- a/capi/src/ime.rs
+++ b/capi/src/ime.rs
@@ -87,7 +87,7 @@ unsafe extern "C" fn ime_event_trampoline(
 }
 
 /// Register a handler for IME composition events on a specific window.
-/// Raw/winit only; no-op on backends where the engine owns composition.
+/// Observed like keyboard events; the engine still owns composition.
 pub fn on_ime_event<F>(window_id: u32, handler: F)
 where
   F: Fn(ImeEvent) + Send + Sync + 'static,

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -21,6 +21,9 @@ mod ffi {
 mod keyboard;
 pub use keyboard::*;
 
+mod ime;
+pub use ime::*;
+
 mod mouse;
 pub use mouse::*;
 
@@ -1252,6 +1255,16 @@ impl Window {
     F: Fn(KeyboardEvent) + Send + Sync + 'static,
   {
     on_keyboard_event(self.id, handler);
+    self
+  }
+
+  /// Register a handler for IME composition events on this window.
+  /// Raw/winit only; no-op on backends where the engine owns composition.
+  pub fn on_ime_event<F>(self, handler: F) -> Self
+  where
+    F: Fn(ImeEvent) + Send + Sync + 'static,
+  {
+    on_ime_event(self.id, handler);
     self
   }
 
@@ -2708,6 +2721,10 @@ where
 
 pub const LAUFEY_KEY_PRESSED: i32 = 0;
 pub const LAUFEY_KEY_RELEASED: i32 = 1;
+
+pub const LAUFEY_IME_START: i32 = 0;
+pub const LAUFEY_IME_UPDATE: i32 = 1;
+pub const LAUFEY_IME_END: i32 = 2;
 
 pub const LAUFEY_MOD_SHIFT: u32 = 1 << 0;
 pub const LAUFEY_MOD_CONTROL: u32 = 1 << 1;

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -1259,7 +1259,9 @@ impl Window {
   }
 
   /// Register a handler for IME composition events on this window.
-  /// Raw/winit only; no-op on backends where the engine owns composition.
+  /// Observed like keyboard events: the engine still owns composition;
+  /// the handler is notified and the event is not consumed. CEF on
+  /// Linux currently has no observer.
   pub fn on_ime_event<F>(self, handler: F) -> Self
   where
     F: Fn(ImeEvent) + Send + Sync + 'static,

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -29,7 +29,7 @@ pub use mouse::*;
 /// (`github.com/denoland/laufey/releases/tag/v{VERSION}`).
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub const LAUFEY_API_VERSION: u32 = 34;
+pub const LAUFEY_API_VERSION: u32 = 35;
 
 /// Creation-time window style flags for [`Window::new_with_options`].
 /// Mirror the `LAUFEY_WINDOW_FLAG_*` constants in `laufey.h`.
@@ -1467,6 +1467,26 @@ impl Window {
           std::ptr::null_mut(),
         );
       }
+    }
+  }
+
+  /// Allow or deny IME on this window. Allowed by default. Can be toggled
+  /// at any time. No-op on backends where the engine owns composition
+  /// (WebView / CEF).
+  pub fn set_ime_allowed(&self, allowed: bool) {
+    let api = api();
+    if let Some(f) = api.set_ime_allowed {
+      unsafe { f(api.backend_data, self.id, allowed) };
+    }
+  }
+
+  /// Set the IME candidate rectangle in logical, top-left client pixels —
+  /// the same space as [`Window::show_context_menu`]. No-op on backends
+  /// without a raw IME (WebView / CEF).
+  pub fn set_ime_cursor_area(&self, x: f64, y: f64, width: f64, height: f64) {
+    let api = api();
+    if let Some(f) = api.set_ime_cursor_area {
+      unsafe { f(api.backend_data, self.id, x, y, width, height) };
     }
   }
 

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -1470,9 +1470,9 @@ impl Window {
     }
   }
 
-  /// Allow or deny IME on this window. Allowed by default. Can be toggled
-  /// at any time. No-op on backends where the engine owns composition
-  /// (WebView / CEF).
+  /// Allow or deny IME on this window. Off by default (winit's default);
+  /// pass `true` when a text field is focused. Can be toggled at any time.
+  /// No-op on backends where the engine owns composition (WebView / CEF).
   pub fn set_ime_allowed(&self, allowed: bool) {
     let api = api();
     if let Some(f) = api.set_ime_allowed {

--- a/cef/src/app.cc
+++ b/cef/src/app.cc
@@ -7,6 +7,7 @@
 #include "scheme_handler.h"
 
 #include <iostream>
+#include <string>
 
 #ifdef __linux__
 #include <gtk/gtk.h>
@@ -62,6 +63,11 @@ void LaufeyWindowDelegate::OnWindowCreated(CefRefPtr<CefWindow> window) {
     }
     RuntimeLoader::GetInstance()->RegisterNativeHandle((void*)(uintptr_t)handle,
                                                        laufey_id_);
+    laufey_common::InstallWinImeObserver(
+        (void*)(uintptr_t)handle, laufey_id_,
+        [](uint32_t id, bool composing, const std::string& data) {
+          RuntimeLoader::GetInstance()->NoteImeState(id, composing, data);
+        });
 #elif defined(__linux__)
     if (no_activate) {
       ConfigureLinuxWindowAsPanel(handle);
@@ -114,12 +120,17 @@ void LaufeyWindowDelegate::OnWindowDestroyed(CefRefPtr<CefWindow> window) {
   if (handle) {
 #ifdef __APPLE__
     UnregisterNSWindowForCefHandle(handle);
+#elif defined(_WIN32)
+    laufey_common::UninstallWinImeObserver((void*)(uintptr_t)handle);
+    RuntimeLoader::GetInstance()->UnregisterNativeHandle(
+        (void*)(uintptr_t)handle);
 #else
     RuntimeLoader::GetInstance()->UnregisterNativeHandle(
         (void*)(uintptr_t)handle);
 #endif
   }
   if (laufey_id_ > 0) {
+    RuntimeLoader::GetInstance()->ClearImeState(laufey_id_);
     RuntimeLoader::GetInstance()->UnregisterBrowser(laufey_id_);
   }
   RemoveNativeMouseMonitor();
@@ -287,6 +298,19 @@ bool LaufeyHandler::OnKeyEvent(CefRefPtr<CefBrowser> browser,
   uint32_t wid = RuntimeLoader::GetInstance()->GetLaufeyIdForBrowser(browser);
   RuntimeLoader::GetInstance()->DispatchKeyboardEvent(
       wid, state, key.c_str(), code.c_str(), modifiers, false);
+#ifdef _WIN32
+  if (wid != 0) {
+    if (auto host = browser->GetHost()) {
+      if (CefWindowHandle hwnd = host->GetWindowHandle()) {
+        laufey_common::InstallWinImeObserver(
+            (void*)(uintptr_t)hwnd, wid,
+            [](uint32_t id, bool composing, const std::string& data) {
+              RuntimeLoader::GetInstance()->NoteImeState(id, composing, data);
+            });
+      }
+    }
+  }
+#endif
 
   return false;  // Don't consume the event — let CEF handle it too
 }

--- a/cef/src/main_mac.mm
+++ b/cef/src/main_mac.mm
@@ -76,6 +76,35 @@ void LaufeyOpenExternalURL(const std::string& url) {
   }
   CefScopedSendingEvent sendingEventScoper;
   [super sendEvent:event];
+  if (event.type == NSEventTypeKeyDown || event.type == NSEventTypeKeyUp ||
+      event.type == NSEventTypeLeftMouseUp) {
+    uint32_t wid = RuntimeLoader::GetInstance()->GetLaufeyIdForNSWindow(
+        (__bridge void*)event.window);
+    if (wid != 0 && event.window) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        id fr = [event.window firstResponder];
+        BOOL composing = NO;
+        std::string data;
+        if ([fr conformsToProtocol:@protocol(NSTextInputClient)]) {
+          id<NSTextInputClient> client = fr;
+          composing = [client hasMarkedText];
+          if (composing) {
+            NSRange range = [client markedRange];
+            if (range.location != NSNotFound && range.length > 0) {
+              NSAttributedString* marked =
+                  [client attributedSubstringForProposedRange:range
+                                                  actualRange:NULL];
+              if (NSString* str = [marked string]) {
+                if (const char* utf8 = [str UTF8String])
+                  data = utf8;
+              }
+            }
+          }
+        }
+        RuntimeLoader::GetInstance()->NoteImeState(wid, composing, data);
+      });
+    }
+  }
 }
 
 - (void)terminate:(id)sender {

--- a/cef/src/runtime_loader.cc
+++ b/cef/src/runtime_loader.cc
@@ -957,6 +957,13 @@ static void Backend_SetKeyboardEventHandler(void* data,
   loader->SetKeyboardEventHandler(handler, user_data);
 }
 
+static void Backend_SetImeEventHandler(void* data,
+                                       laufey_ime_event_fn handler,
+                                       void* user_data) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  loader->SetImeEventHandler(handler, user_data);
+}
+
 static void Backend_SetMouseClickHandler(void* data,
                                          laufey_mouse_click_fn handler,
                                          void* user_data) {
@@ -1821,6 +1828,7 @@ void RuntimeLoader::InitializeBackendApi() {
 #endif
 
   backend_api_.set_keyboard_event_handler = Backend_SetKeyboardEventHandler;
+  backend_api_.set_ime_event_handler = Backend_SetImeEventHandler;
   backend_api_.set_mouse_click_handler = Backend_SetMouseClickHandler;
   backend_api_.set_mouse_move_handler = Backend_SetMouseMoveHandler;
   backend_api_.set_wheel_handler = Backend_SetWheelHandler;

--- a/cef/src/runtime_loader.h
+++ b/cef/src/runtime_loader.h
@@ -210,6 +210,41 @@ class RuntimeLoader {
     }
   }
 
+  void SetImeEventHandler(laufey_ime_event_fn handler, void* user_data) {
+    std::lock_guard<std::mutex> lock(ime_mutex_);
+    ime_handler_ = handler;
+    ime_user_data_ = user_data;
+  }
+
+  void NoteImeState(uint32_t window_id, bool composing,
+                    const std::string& data) {
+    std::lock_guard<std::mutex> lock(ime_mutex_);
+    bool was = false;
+    auto it = ime_composing_.find(window_id);
+    if (it != ime_composing_.end()) {
+      was = it->second;
+    }
+    auto emit = [&](int type, const char* d) {
+      if (ime_handler_) {
+        ime_handler_(ime_user_data_, window_id, type, d);
+      }
+    };
+    if (!was && composing) {
+      emit(LAUFEY_IME_START, "");
+      emit(LAUFEY_IME_UPDATE, data.c_str());
+    } else if (was && composing) {
+      emit(LAUFEY_IME_UPDATE, data.c_str());
+    } else if (was && !composing) {
+      emit(LAUFEY_IME_END, data.c_str());
+    }
+    ime_composing_[window_id] = composing;
+  }
+
+  void ClearImeState(uint32_t window_id) {
+    std::lock_guard<std::mutex> lock(ime_mutex_);
+    ime_composing_.erase(window_id);
+  }
+
   void SetMouseClickHandler(laufey_mouse_click_fn handler, void* user_data) {
     std::lock_guard<std::mutex> lock(mouse_mutex_);
     mouse_click_handler_ = handler;
@@ -423,6 +458,11 @@ class RuntimeLoader {
   laufey_keyboard_event_fn keyboard_handler_ = nullptr;
   void* keyboard_user_data_ = nullptr;
   std::mutex keyboard_mutex_;
+
+  laufey_ime_event_fn ime_handler_ = nullptr;
+  void* ime_user_data_ = nullptr;
+  std::mutex ime_mutex_;
+  std::map<uint32_t, bool> ime_composing_;
 
   laufey_mouse_click_fn mouse_click_handler_ = nullptr;
   void* mouse_click_user_data_ = nullptr;

--- a/cef/src/runtime_loader.h
+++ b/cef/src/runtime_loader.h
@@ -15,6 +15,7 @@
 #include "include/cef_browser.h"
 #include "include/cef_values.h"
 #include <laufey.h>
+#include "ime_key_echo.h"
 
 // laufey_value and the value_* marshalling are shared across backends
 // (backend-common/include/laufey_value.h). CEF stores values as laufey::Value
@@ -204,6 +205,10 @@ class RuntimeLoader {
                              const char* code, uint32_t modifiers,
                              bool repeat) {
     std::lock_guard<std::mutex> lock(keyboard_mutex_);
+    if (laufey_common::ConsumeImeKeyEcho(&ime_key_echo_[window_id], state, key,
+                                         code)) {
+      return;
+    }
     if (keyboard_handler_) {
       keyboard_handler_(keyboard_user_data_, window_id, state, key, code,
                         modifiers, repeat);
@@ -458,6 +463,7 @@ class RuntimeLoader {
   laufey_keyboard_event_fn keyboard_handler_ = nullptr;
   void* keyboard_user_data_ = nullptr;
   std::mutex keyboard_mutex_;
+  std::map<uint32_t, laufey_common::ImeKeyEcho> ime_key_echo_;
 
   laufey_ime_event_fn ime_handler_ = nullptr;
   void* ime_user_data_ = nullptr;

--- a/cef/src/runtime_loader.h
+++ b/cef/src/runtime_loader.h
@@ -205,8 +205,8 @@ class RuntimeLoader {
                              const char* code, uint32_t modifiers,
                              bool repeat) {
     std::lock_guard<std::mutex> lock(keyboard_mutex_);
-    if (laufey_common::ConsumeImeKeyEcho(&ime_key_echo_[window_id], state, key,
-                                         code)) {
+    if (laufey_common::ConsumeImeKeyEcho(&ime_key_echo_[window_id], state,
+                                         repeat, code)) {
       return;
     }
     if (keyboard_handler_) {

--- a/docs/c-abi.md
+++ b/docs/c-abi.md
@@ -54,7 +54,7 @@ The pointers group into:
   `invoke_js_callback`, `release_js_callback`, `execute_js`, `set_js_namespace`,
   `poll_js_calls`, `set_js_call_notify`.
 - **Event handlers** — `set_keyboard_event_handler`, `set_ime_event_handler`
-  (composition start/update/end, API ≥ 35, raw/winit only),
+  (composition start/update/end, API ≥ 35; observed like keyboard, not consumed),
   `set_mouse_click_handler`, `set_mouse_move_handler`, `set_wheel_handler`,
   `set_cursor_enter_leave_handler`, `set_focused_handler`, `set_resize_handler`,
   `set_move_handler`, `set_close_requested_handler` (defer-until-close_window

--- a/docs/c-abi.md
+++ b/docs/c-abi.md
@@ -53,8 +53,9 @@ The pointers group into:
 - **JavaScript interop** — `set_js_call_handler`, `js_call_respond`,
   `invoke_js_callback`, `release_js_callback`, `execute_js`, `set_js_namespace`,
   `poll_js_calls`, `set_js_call_notify`.
-- **Event handlers** — `set_keyboard_event_handler`, `set_mouse_click_handler`,
-  `set_mouse_move_handler`, `set_wheel_handler`,
+- **Event handlers** — `set_keyboard_event_handler`, `set_ime_event_handler`
+  (composition start/update/end, API ≥ 35, raw/winit only),
+  `set_mouse_click_handler`, `set_mouse_move_handler`, `set_wheel_handler`,
   `set_cursor_enter_leave_handler`, `set_focused_handler`, `set_resize_handler`,
   `set_move_handler`, `set_close_requested_handler` (defer-until-close_window
   contract as of API ≥ 31 — see below).

--- a/docs/input-events.md
+++ b/docs/input-events.md
@@ -21,9 +21,12 @@ translates its own native event source — Chromium's event path under CEF,
 `NSEvent` on macOS, GDK on Linux, and the Win32 message loop on Windows — into
 this common shape, so the same handler works on every backend.
 
-IME composition is raw/winit only (WebView and CEF leave the handler unset
-because the engine owns composition). Call `set_ime_allowed(true)` when a text
-field is focused, then `on_ime_event` delivers the W3C sequence:
+IME composition is observed the same way as keyboard events: the handler
+runs, the event is not consumed. On raw/winit, call `set_ime_allowed(true)`
+when a text field is focused so composition can start. WebView and CEF
+already compose inside the engine; they still forward `on_ime_event` so the
+runtime can see the session. `on_ime_event` delivers the W3C sequence:
 `Start` (empty data) → one or more `Update`s with the preedit string → `End`
 with the committed string (empty if the session was cancelled). Keyboard
-events continue to fire during composition.
+events continue to fire during composition. CEF on Linux does not yet
+observe IME.

--- a/docs/input-events.md
+++ b/docs/input-events.md
@@ -7,6 +7,7 @@ lets the application observe or react to raw input.
 ```rust
 let win = Window::new(800, 600)
   .on_keyboard_event(|e| println!("{} {:?}", e.key, e.modifiers))
+  .on_ime_event(|e| println!("{:?} {}", e.state, e.data))
   .on_mouse_click(|e| println!("button {} at {},{}", e.button, e.x, e.y))
   .on_wheel(|e| println!("scroll {},{}", e.delta_x, e.delta_y))
   .on_cursor_enter_leave(|e| println!("entered: {}", e.entered))
@@ -19,3 +20,10 @@ cursor position, the active modifiers, and the click count. Each backend
 translates its own native event source — Chromium's event path under CEF,
 `NSEvent` on macOS, GDK on Linux, and the Win32 message loop on Windows — into
 this common shape, so the same handler works on every backend.
+
+IME composition is raw/winit only (WebView and CEF leave the handler unset
+because the engine owns composition). Call `set_ime_allowed(true)` when a text
+field is focused, then `on_ime_event` delivers the W3C sequence:
+`Start` (empty data) → one or more `Update`s with the preedit string → `End`
+with the committed string (empty if the session was cancelled). Keyboard
+events continue to fire during composition.

--- a/docs/input-events.md
+++ b/docs/input-events.md
@@ -28,5 +28,6 @@ already compose inside the engine; they still forward `on_ime_event` so the
 runtime can see the session. `on_ime_event` delivers the W3C sequence:
 `Start` (empty data) → one or more `Update`s with the preedit string → `End`
 with the committed string (empty if the session was cancelled). Keyboard
-events continue to fire during composition. CEF on Linux does not yet
-observe IME.
+events continue to fire during composition. A second `keydown` that Japanese
+IMEs (e.g. Google ひらがな) post for the same physical key is dropped.
+CEF on Linux does not yet observe IME.

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -473,24 +473,6 @@ static void Backend_ShowContextMenu(void* data, uint32_t window_id, int x,
   }
 }
 
-static void Backend_SetImeAllowed(void* data, uint32_t window_id,
-                                  bool allowed) {
-  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
-  LaufeyBackend* backend = loader->GetBackend();
-  if (backend) {
-    backend->SetImeAllowed(window_id, allowed);
-  }
-}
-
-static void Backend_SetImeCursorArea(void* data, uint32_t window_id, double x,
-                                     double y, double width, double height) {
-  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
-  LaufeyBackend* backend = loader->GetBackend();
-  if (backend) {
-    backend->SetImeCursorArea(window_id, x, y, width, height);
-  }
-}
-
 static void Backend_OpenDevTools(void* data, uint32_t window_id) {
   RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
   LaufeyBackend* backend = loader->GetBackend();
@@ -842,8 +824,6 @@ void RuntimeLoader::InitializeBackendApi() {
   backend_api_.set_js_call_notify = Backend_SetJsCallNotify;
   backend_api_.set_application_menu = Backend_SetApplicationMenu;
   backend_api_.show_context_menu = Backend_ShowContextMenu;
-  backend_api_.set_ime_allowed = Backend_SetImeAllowed;
-  backend_api_.set_ime_cursor_area = Backend_SetImeCursorArea;
   backend_api_.open_devtools = Backend_OpenDevTools;
   backend_api_.print_to_pdf = Backend_PrintToPdf;
   backend_api_.set_js_namespace = Backend_SetJsNamespace;

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -473,6 +473,24 @@ static void Backend_ShowContextMenu(void* data, uint32_t window_id, int x,
   }
 }
 
+static void Backend_SetImeAllowed(void* data, uint32_t window_id,
+                                  bool allowed) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  LaufeyBackend* backend = loader->GetBackend();
+  if (backend) {
+    backend->SetImeAllowed(window_id, allowed);
+  }
+}
+
+static void Backend_SetImeCursorArea(void* data, uint32_t window_id, double x,
+                                     double y, double width, double height) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  LaufeyBackend* backend = loader->GetBackend();
+  if (backend) {
+    backend->SetImeCursorArea(window_id, x, y, width, height);
+  }
+}
+
 static void Backend_OpenDevTools(void* data, uint32_t window_id) {
   RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
   LaufeyBackend* backend = loader->GetBackend();
@@ -824,6 +842,8 @@ void RuntimeLoader::InitializeBackendApi() {
   backend_api_.set_js_call_notify = Backend_SetJsCallNotify;
   backend_api_.set_application_menu = Backend_SetApplicationMenu;
   backend_api_.show_context_menu = Backend_ShowContextMenu;
+  backend_api_.set_ime_allowed = Backend_SetImeAllowed;
+  backend_api_.set_ime_cursor_area = Backend_SetImeCursorArea;
   backend_api_.open_devtools = Backend_OpenDevTools;
   backend_api_.print_to_pdf = Backend_PrintToPdf;
   backend_api_.set_js_namespace = Backend_SetJsNamespace;

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -385,6 +385,13 @@ static void Backend_SetKeyboardEventHandler(void* data,
   loader->SetKeyboardEventHandler(handler, user_data);
 }
 
+static void Backend_SetImeEventHandler(void* data,
+                                       laufey_ime_event_fn handler,
+                                       void* user_data) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  loader->SetImeEventHandler(handler, user_data);
+}
+
 static void Backend_SetMouseClickHandler(void* data,
                                          laufey_mouse_click_fn handler,
                                          void* user_data) {
@@ -812,6 +819,7 @@ void RuntimeLoader::InitializeBackendApi() {
   };
 
   backend_api_.set_keyboard_event_handler = Backend_SetKeyboardEventHandler;
+  backend_api_.set_ime_event_handler = Backend_SetImeEventHandler;
   backend_api_.set_mouse_click_handler = Backend_SetMouseClickHandler;
   backend_api_.set_mouse_move_handler = Backend_SetMouseMoveHandler;
   backend_api_.set_wheel_handler = Backend_SetWheelHandler;

--- a/webview/src/runtime_loader.h
+++ b/webview/src/runtime_loader.h
@@ -11,6 +11,7 @@
 #include <map>
 
 #include "laufey.h"
+#include "ime_key_echo.h"
 #include "scheme_exchange.h"
 #include "webview_value.h"
 
@@ -112,6 +113,10 @@ class RuntimeLoader {
                              const char* code, uint32_t modifiers,
                              bool repeat) {
     std::lock_guard<std::mutex> lock(keyboard_mutex_);
+    if (laufey_common::ConsumeImeKeyEcho(&ime_key_echo_[window_id], state, key,
+                                         code)) {
+      return;
+    }
     if (keyboard_handler_) {
       keyboard_handler_(keyboard_user_data_, window_id, state, key, code,
                         modifiers, repeat);
@@ -350,6 +355,7 @@ class RuntimeLoader {
   laufey_keyboard_event_fn keyboard_handler_ = nullptr;
   void* keyboard_user_data_ = nullptr;
   std::mutex keyboard_mutex_;
+  std::map<uint32_t, laufey_common::ImeKeyEcho> ime_key_echo_;
 
   laufey_ime_event_fn ime_handler_ = nullptr;
   void* ime_user_data_ = nullptr;

--- a/webview/src/runtime_loader.h
+++ b/webview/src/runtime_loader.h
@@ -118,6 +118,49 @@ class RuntimeLoader {
     }
   }
 
+  void SetImeEventHandler(laufey_ime_event_fn handler, void* user_data) {
+    std::lock_guard<std::mutex> lock(ime_mutex_);
+    ime_handler_ = handler;
+    ime_user_data_ = user_data;
+  }
+
+  void DispatchImeEvent(uint32_t window_id, int type, const char* data) {
+    std::lock_guard<std::mutex> lock(ime_mutex_);
+    if (ime_handler_) {
+      ime_handler_(ime_user_data_, window_id, type, data ? data : "");
+    }
+  }
+
+  // Observe an IME session the same way keyboard events are observed:
+  // the engine still owns composition; we just forward start/update/end.
+  void NoteImeState(uint32_t window_id, bool composing, const std::string& data) {
+    std::lock_guard<std::mutex> lock(ime_mutex_);
+    bool was = false;
+    auto it = ime_composing_.find(window_id);
+    if (it != ime_composing_.end()) {
+      was = it->second;
+    }
+    auto emit = [&](int type, const char* d) {
+      if (ime_handler_) {
+        ime_handler_(ime_user_data_, window_id, type, d);
+      }
+    };
+    if (!was && composing) {
+      emit(LAUFEY_IME_START, "");
+      emit(LAUFEY_IME_UPDATE, data.c_str());
+    } else if (was && composing) {
+      emit(LAUFEY_IME_UPDATE, data.c_str());
+    } else if (was && !composing) {
+      emit(LAUFEY_IME_END, data.c_str());
+    }
+    ime_composing_[window_id] = composing;
+  }
+
+  void ClearImeState(uint32_t window_id) {
+    std::lock_guard<std::mutex> lock(ime_mutex_);
+    ime_composing_.erase(window_id);
+  }
+
   void SetMouseClickHandler(laufey_mouse_click_fn handler, void* user_data) {
     std::lock_guard<std::mutex> lock(mouse_mutex_);
     mouse_click_handler_ = handler;
@@ -307,6 +350,11 @@ class RuntimeLoader {
   laufey_keyboard_event_fn keyboard_handler_ = nullptr;
   void* keyboard_user_data_ = nullptr;
   std::mutex keyboard_mutex_;
+
+  laufey_ime_event_fn ime_handler_ = nullptr;
+  void* ime_user_data_ = nullptr;
+  std::mutex ime_mutex_;
+  std::map<uint32_t, bool> ime_composing_;
 
   laufey_mouse_click_fn mouse_click_handler_ = nullptr;
   void* mouse_click_user_data_ = nullptr;

--- a/webview/src/runtime_loader.h
+++ b/webview/src/runtime_loader.h
@@ -449,13 +449,6 @@ class LaufeyBackend {
                                laufey_menu_click_fn on_click,
                                void* on_click_data) = 0;
 
-  // IME (API >= 35). Default no-op; the engine owns composition. The raw
-  // backend overrides.
-  virtual void SetImeAllowed(uint32_t /*window_id*/, bool /*allowed*/) {}
-  virtual void SetImeCursorArea(uint32_t /*window_id*/, double /*x*/,
-                                double /*y*/, double /*width*/,
-                                double /*height*/) {}
-
   virtual void OpenDevTools(uint32_t window_id) = 0;
 
   // Render the window's current page to a PDF (API >= 32). The PDF bytes are

--- a/webview/src/runtime_loader.h
+++ b/webview/src/runtime_loader.h
@@ -449,6 +449,13 @@ class LaufeyBackend {
                                laufey_menu_click_fn on_click,
                                void* on_click_data) = 0;
 
+  // IME (API >= 35). Default no-op; the engine owns composition. The raw
+  // backend overrides.
+  virtual void SetImeAllowed(uint32_t /*window_id*/, bool /*allowed*/) {}
+  virtual void SetImeCursorArea(uint32_t /*window_id*/, double /*x*/,
+                                double /*y*/, double /*width*/,
+                                double /*height*/) {}
+
   virtual void OpenDevTools(uint32_t window_id) = 0;
 
   // Render the window's current page to a PDF (API >= 32). The PDF bytes are

--- a/webview/src/runtime_loader.h
+++ b/webview/src/runtime_loader.h
@@ -113,8 +113,8 @@ class RuntimeLoader {
                              const char* code, uint32_t modifiers,
                              bool repeat) {
     std::lock_guard<std::mutex> lock(keyboard_mutex_);
-    if (laufey_common::ConsumeImeKeyEcho(&ime_key_echo_[window_id], state, key,
-                                         code)) {
+    if (laufey_common::ConsumeImeKeyEcho(&ime_key_echo_[window_id], state,
+                                         repeat, code)) {
       return;
     }
     if (keyboard_handler_) {

--- a/webview/src/webview_linux.cc
+++ b/webview/src/webview_linux.cc
@@ -454,6 +454,68 @@ static WebKitGTKBackend* g_gtk_backend = nullptr;
 static std::map<WebKitUserContentManager*, uint32_t>
     g_content_manager_to_laufey_id;
 
+#if WEBKIT_CHECK_VERSION(2, 28, 0)
+static std::map<WebKitInputMethodContext*, uint32_t> g_im_to_laufey_id;
+
+static void on_im_preedit_started(WebKitInputMethodContext* im, gpointer) {
+  auto it = g_im_to_laufey_id.find(im);
+  if (it == g_im_to_laufey_id.end())
+    return;
+  RuntimeLoader::GetInstance()->NoteImeState(it->second, true, "");
+}
+
+static void on_im_preedit_changed(WebKitInputMethodContext* im, gpointer) {
+  auto it = g_im_to_laufey_id.find(im);
+  if (it == g_im_to_laufey_id.end())
+    return;
+  gchar* text = nullptr;
+  webkit_input_method_context_get_preedit(im, &text, nullptr, nullptr);
+  RuntimeLoader::GetInstance()->NoteImeState(it->second, true,
+                                             text ? text : "");
+  g_free(text);
+}
+
+static void on_im_preedit_finished(WebKitInputMethodContext* im, gpointer) {
+  auto it = g_im_to_laufey_id.find(im);
+  if (it == g_im_to_laufey_id.end())
+    return;
+  RuntimeLoader::GetInstance()->NoteImeState(it->second, false, "");
+}
+
+static void on_im_committed(WebKitInputMethodContext* im, gchar* str,
+                            gpointer) {
+  auto it = g_im_to_laufey_id.find(im);
+  if (it == g_im_to_laufey_id.end())
+    return;
+  RuntimeLoader::GetInstance()->NoteImeState(it->second, false,
+                                             str ? str : "");
+}
+
+static void AttachImeObserver(WebKitWebView* webview, uint32_t window_id) {
+  WebKitInputMethodContext* im =
+      webkit_web_view_get_input_method_context(webview);
+  if (!im)
+    return;
+  if (g_im_to_laufey_id.count(im))
+    return;
+  g_im_to_laufey_id[im] = window_id;
+  g_signal_connect(im, "preedit-started", G_CALLBACK(on_im_preedit_started),
+                   nullptr);
+  g_signal_connect(im, "preedit-changed", G_CALLBACK(on_im_preedit_changed),
+                   nullptr);
+  g_signal_connect(im, "preedit-finished", G_CALLBACK(on_im_preedit_finished),
+                   nullptr);
+  g_signal_connect(im, "committed", G_CALLBACK(on_im_committed), nullptr);
+}
+
+static void DetachImeObserver(WebKitWebView* webview) {
+  WebKitInputMethodContext* im =
+      webkit_web_view_get_input_method_context(webview);
+  if (im)
+    g_im_to_laufey_id.erase(im);
+}
+#endif
+
 static void on_script_message(WebKitUserContentManager* manager,
                               WebKitJavascriptResult* js_result,
                               gpointer user_data) {
@@ -744,6 +806,9 @@ void WebKitGTKBackend::CreateWindowEx(uint32_t window_id, int width, int height,
     g_signal_connect(webview, "load-changed", G_CALLBACK(on_load_changed),
                      GUINT_TO_POINTER(window_id));
     g_signal_connect(webview, "create", G_CALLBACK(on_create), nullptr);
+#if WEBKIT_CHECK_VERSION(2, 28, 0)
+    AttachImeObserver(webview, window_id);
+#endif
 
     WebKitSettings* wk_settings = webkit_web_view_get_settings(webview);
     webkit_settings_set_enable_developer_extras(wk_settings, TRUE);
@@ -804,6 +869,10 @@ void WebKitGTKBackend::CloseWindow(uint32_t window_id) {
     std::lock_guard<std::mutex> lock(windows_mutex_);
     auto* state = GetWindow(window_id);
     if (state) {
+#if WEBKIT_CHECK_VERSION(2, 28, 0)
+      DetachImeObserver(state->webview);
+#endif
+      RuntimeLoader::GetInstance()->ClearImeState(window_id);
       webkit_user_content_manager_unregister_script_message_handler(
           state->content_manager, "laufey");
       g_content_manager_to_laufey_id.erase(state->content_manager);

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <map>
 #include <mutex>
+#include <string>
 
 @class LaufeyScriptMessageHandler;
 @class LaufeyWindowDelegate;
@@ -205,6 +206,36 @@ static uint32_t LaufeyIdForNSWindow(NSWindow* win) {
   std::lock_guard<std::mutex> lock(g_nswindow_mutex);
   auto it = g_nswindow_to_laufey_id.find((__bridge void*)win);
   return it != g_nswindow_to_laufey_id.end() ? it->second : 0;
+}
+
+// Query NSTextInputClient after the webview has handled the event so
+// marked text reflects the current composition. Matches keyboard
+// observation: we do not consume the event.
+static void ObserveImeForWindow(NSWindow* win, uint32_t wid) {
+  if (!win || wid == 0)
+    return;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    id fr = [win firstResponder];
+    BOOL composing = NO;
+    std::string data;
+    if ([fr conformsToProtocol:@protocol(NSTextInputClient)]) {
+      id<NSTextInputClient> client = fr;
+      composing = [client hasMarkedText];
+      if (composing) {
+        NSRange range = [client markedRange];
+        if (range.location != NSNotFound && range.length > 0) {
+          NSAttributedString* marked =
+              [client attributedSubstringForProposedRange:range
+                                              actualRange:NULL];
+          if (NSString* str = [marked string]) {
+            if (const char* utf8 = [str UTF8String])
+              data = utf8;
+          }
+        }
+      }
+    }
+    RuntimeLoader::GetInstance()->NoteImeState(wid, composing, data);
+  });
 }
 
 static void RegisterNSWindow(NSWindow* win, uint32_t window_id) {
@@ -704,6 +735,7 @@ void WKWebViewBackend::RemoveWindowState(uint32_t window_id) {
 void WKWebViewBackend::OnWindowClosedByUser(uint32_t window_id) {
   // Main thread (AppKit delivers windowWillClose: there); safe to take the
   // lock and tear down state while the window finishes closing.
+  RuntimeLoader::GetInstance()->ClearImeState(window_id);
   std::lock_guard<std::mutex> lock(windows_mutex_);
   RemoveWindowState(window_id);
 }
@@ -739,6 +771,7 @@ void WKWebViewBackend::InstallGlobalMonitors() {
                                          ->DispatchKeyboardEvent(
                                              wid, state, key.c_str(),
                                              code.c_str(), modifiers, repeat);
+                                     ObserveImeForWindow(win, wid);
 
                                      return event;
                                    }];
@@ -788,6 +821,7 @@ void WKWebViewBackend::InstallGlobalMonitors() {
                                          ->DispatchMouseClickEvent(
                                              wid, state, button, x, y,
                                              modifiers, click_count);
+                                     ObserveImeForWindow(win, wid);
 
                                      return event;
                                    }];

--- a/webview/src/webview_windows.cc
+++ b/webview/src/webview_windows.cc
@@ -547,6 +547,18 @@ LRESULT CALLBACK WebView2Backend::WindowProc(HWND hwnd, UINT msg, WPARAM wParam,
           false);
       break;
     }
+    case WM_IME_STARTCOMPOSITION:
+    case WM_IME_COMPOSITION:
+    case WM_IME_ENDCOMPOSITION: {
+      if (wid == 0)
+        break;
+      laufey_common::HandleWinImeMessage(
+          hwnd, msg, wParam, lParam, wid,
+          [](uint32_t id, bool composing, const std::string& data) {
+            RuntimeLoader::GetInstance()->NoteImeState(id, composing, data);
+          });
+      break;
+    }
     case WM_CLOSE: {
       bool proceed = true;
       if (wid > 0) {
@@ -573,6 +585,10 @@ LRESULT CALLBACK WebView2Backend::WindowProc(HWND hwnd, UINT msg, WPARAM wParam,
       // closes and for CloseWindow()'s direct DestroyWindow alike, so a
       // deferred close resolved via close_window still quits the message
       // loop when the last window goes away.
+      if (wid > 0) {
+        RuntimeLoader::GetInstance()->ClearImeState(wid);
+      }
+      laufey_common::UninstallWinImeObserver(hwnd);
       std::lock_guard<std::recursive_mutex> lock(g_hwnd_mutex);
       if (g_hwnd_to_laufey_id.erase(hwnd) > 0 && g_hwnd_to_laufey_id.empty()) {
         PostQuitMessage(0);
@@ -823,6 +839,12 @@ void WebView2Backend::OnEnvironmentReady(uint32_t window_id, HWND hwnd,
 
             state->controller = controller;
             controller->get_CoreWebView2(&state->webview);
+            laufey_common::InstallWinImeObserver(
+                hwnd, window_id,
+                [](uint32_t id, bool composing, const std::string& data) {
+                  RuntimeLoader::GetInstance()->NoteImeState(id, composing,
+                                                             data);
+                });
 
             RECT bounds;
             GetClientRect(hwnd, &bounds);

--- a/winit/src/main.rs
+++ b/winit/src/main.rs
@@ -398,7 +398,16 @@ impl ApplicationHandler<UserEvent> for App {
       WindowEvent::DroppedFile(_) => {}
       WindowEvent::HoveredFile(_) => {}
       WindowEvent::HoveredFileCancelled => {}
-      WindowEvent::Ime(_) => {}
+      WindowEvent::Ime(ref ime) => {
+        state.common.with_window(laufey_id, |ws| {
+          laufey_backend_winit_common::dispatch_ime_event(
+            &state.common.handlers,
+            ws,
+            laufey_id,
+            ime,
+          );
+        });
+      }
 
       WindowEvent::Touch(_)
       | WindowEvent::PinchGesture { .. }

--- a/winit/src/main.rs
+++ b/winit/src/main.rs
@@ -219,7 +219,9 @@ impl ApplicationHandler<UserEvent> for App {
             | CommonEvent::Hide { window_id }
             | CommonEvent::Focus { window_id }
             | CommonEvent::SetApplicationMenu { window_id }
-            | CommonEvent::ShowContextMenu { window_id } => *window_id,
+            | CommonEvent::ShowContextMenu { window_id }
+            | CommonEvent::SetImeAllowed { window_id }
+            | CommonEvent::SetImeCursorArea { window_id } => *window_id,
             _ => return,
           };
           if let Some(info) = self.windows.get(&wid) {

--- a/winit/src/main.rs
+++ b/winit/src/main.rs
@@ -312,12 +312,15 @@ impl ApplicationHandler<UserEvent> for App {
         event: ref key_event,
         ..
       } => {
-        laufey_backend_winit_common::dispatch_keyboard_event(
-          &state.common.handlers,
-          laufey_id,
-          key_event,
-          *modifiers,
-        );
+        state.common.with_window(laufey_id, |ws| {
+          laufey_backend_winit_common::dispatch_keyboard_event(
+            &state.common.handlers,
+            ws,
+            laufey_id,
+            key_event,
+            *modifiers,
+          );
+        });
       }
       WindowEvent::CursorMoved { position, .. } => {
         state.common.with_window(laufey_id, |ws| {


### PR DESCRIPTION
## Summary

Raw/winit windows create with IME off (winit's default), so CJK composition never starts until the app opts in. WebView and CEF already compose because the engine owns IME.

This bumps the C ABI to **v35** and:

- keeps IME **off by default** on the winit backend (matches winit; games and other raw-key clients are unchanged)
- adds `set_ime_allowed` / `set_ime_cursor_area` to `laufey_backend_api_t` and the Rust `Window` API — call `set_ime_allowed(true)` when a text field is focused (raw/winit only; WebView and CEF leave these pointers null)
- adds `set_ime_event_handler` / `Window::on_ime_event` so runtimes receive the W3C composition sequence (`Start` → `Update`* → `End`). `Ime::Enabled` is a capability signal, not a session; `compositionstart` fires on the first `Preedit` or `Commit`
- observes composition on WebView and CEF the same way keyboard events are observed: the engine still owns IME, the handler is notified, the event is not consumed (macOS `NSTextInputClient`, Windows `WM_IME_*`, Linux WebKit `WebKitInputMethodContext`). CEF on Linux has no observer yet

`set_ime_cursor_area` is a logical, top-left client rectangle (typically the caret or an in-window field). It is not reapplied on move/resize — callers update it when the caret moves.

## Related

- https://github.com/denoland/deno/issues/36752
- https://github.com/denoland/deno/pull/36754

## AI Disclosure

This PR was drafted and filed by an AI assistant (Grok). I reviewed and edited it myself.