### PR TITLE
fix(capi): add `run_on_ui_thread` for AppKit-safe hops

### DIFF
--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -665,6 +665,65 @@ pub fn quit() {
   }
 }
 
+/// Run `f` on the backend UI thread and block until it returns.
+///
+/// Only hops on Apple platforms, where AppKit requires main-thread access
+/// (e.g. `raw-window-metal` / `NSView`). Elsewhere `f` runs inline.
+///
+/// On Apple, posts through the C ABI `post_ui_task` (winit event loop /
+/// GCD main / CEF `TID_UI`) unless already on the process main thread
+/// (`pthread_main_np`) or the backend has no `post_ui_task`. Prefer this
+/// over `dispatch_sync`, which deadlocks against a backend that owns the
+/// main run loop (winit).
+///
+/// # Panics
+///
+/// Panics if the UI task is dropped without running (backend tore down
+/// while the caller was waiting).
+pub fn run_on_ui_thread<F, R>(f: F) -> R
+where
+  F: FnOnce() -> R + Send + 'static,
+  R: Send + 'static,
+{
+  #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+  {
+    return f();
+  }
+
+  #[cfg(any(target_os = "macos", target_os = "ios"))]
+  {
+    unsafe extern "C" {
+      fn pthread_main_np() -> i32;
+    }
+    // SAFETY: libSystem symbol on Apple.
+    if unsafe { pthread_main_np() != 0 } {
+      return f();
+    }
+    let api = api();
+    let Some(post) = api.post_ui_task else {
+      return f();
+    };
+
+    let (tx, rx) = std::sync::mpsc::sync_channel(0);
+    type Job = Box<dyn FnOnce() + Send>;
+    let job = Box::into_raw(Box::new(Box::new(move || {
+      let _ = tx.send(f());
+    }) as Job));
+
+    unsafe extern "C" fn trampoline(data: *mut c_void) {
+      // SAFETY: `data` is the `Box<Job>` passed to `post_ui_task`; not retained.
+      let job = unsafe { Box::from_raw(data as *mut Job) };
+      (*job)();
+    }
+
+    // SAFETY: trampoline owns and frees `job`; we block until it runs.
+    unsafe {
+      post(api.backend_data, Some(trampoline), job as *mut c_void);
+    }
+    rx.recv().expect("UI task dropped without running")
+  }
+}
+
 // --- Window ---
 
 pub struct Window {
@@ -3258,12 +3317,32 @@ mod tests {
     }
   }
 
+  // Mimic real backends: deliver the task on another thread so
+  // `run_on_ui_thread` must actually wait (inline delivery would not
+  // exercise the channel rendezvous).
+  unsafe extern "C" fn fake_post_ui_task(
+    _backend_data: *mut c_void,
+    task: Option<unsafe extern "C" fn(*mut c_void)>,
+    data: *mut c_void,
+  ) {
+    let Some(task) = task else {
+      return;
+    };
+    let data = data as usize;
+    std::thread::spawn(move || {
+      // SAFETY: caller of run_on_ui_thread keeps `data` live until the
+      // rendezvous send inside the trampoline.
+      unsafe { task(data as *mut c_void) };
+    });
+  }
+
   // Install the shared fake backend. BACKEND_API is a set-once global and the
-  // pdf tests run concurrently, so every caller installs the *same* fake and
-  // the first one wins.
+  // pdf / run_on_ui_thread tests run concurrently, so every caller installs
+  // the *same* fake and the first one wins.
   fn install_pdf_fake() {
     let mut fake: LaufeyBackendApi = unsafe { std::mem::zeroed() };
     fake.print_to_pdf = Some(fake_print_to_pdf);
+    fake.post_ui_task = Some(fake_post_ui_task);
     let _ = BACKEND_API.set(Box::leak(Box::new(fake)));
   }
 
@@ -3353,5 +3432,33 @@ mod tests {
       rx.try_recv().is_err(),
       "late completion must not invoke the callback a second time"
     );
+  }
+
+  // run_on_ui_thread returns the closure's value. On Apple the hop path is
+  // exercised from a worker (the test runner is main and would inline);
+  // elsewhere the function is a plain call.
+  #[test]
+  fn run_on_ui_thread_hops_and_returns_value() {
+    install_pdf_fake();
+
+    let run = || {
+      assert_eq!(run_on_ui_thread(|| 42u32), 42);
+      let err: Result<(), &str> =
+        run_on_ui_thread(|| Err("surface failed"));
+      assert_eq!(err, Err("surface failed"));
+      let flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+      let flag2 = flag.clone();
+      run_on_ui_thread(move || {
+        flag2.store(true, std::sync::atomic::Ordering::SeqCst);
+      });
+      assert!(flag.load(std::sync::atomic::Ordering::SeqCst));
+    };
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    std::thread::spawn(run)
+      .join()
+      .expect("run_on_ui_thread worker panicked");
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    run();
   }
 }


### PR DESCRIPTION
## Summary

macOS AppKit requires main-thread access for `NSView` / `CAMetalLayer`
(e.g. wgpu surface creation via `raw-window-metal`). Deno Desktop's runtime
thread is not the UI thread, so callers need a blocking hop onto the backend
event loop.

This adds `laufey::run_on_ui_thread`:

- **Apple**: posts through the existing C ABI `post_ui_task` (winit event
  loop / GCD main / CEF `TID_UI`), unless already on the process main thread
  (`pthread_main_np`) or the backend has no `post_ui_task`
- **elsewhere**: runs the closure inline (no hop needed today)
- **no ABI bump** — wraps the existing `post_ui_task` pointer

Prefer this over `dispatch_sync`, which deadlocks against a backend that owns
the main run loop (winit).

## Related

https://github.com/denoland/deno/pull/36756

## AI Disclosure

This PR was drafted and filed by an AI assistant (Grok). I reviewed and edited
it myself.