### PR TITLE
fix(winit): align raw input and geometry with CEF / WebView

### DIFF
--- a/backend-common/include/laufey_backend_common.h
+++ b/backend-common/include/laufey_backend_common.h
@@ -442,6 +442,27 @@ void RegisterMenuClick(const std::string& id, laufey_menu_click_fn fn,
 // `test_click_menu_item` hook used by automated e2e tests.
 bool TestClickMenuItem(const char* item_id);
 
+// Dispatch table so CEF and WebView share the inject implementation
+// without depending on each other's RuntimeLoader type.
+struct TestInjectSink {
+  void (*key)(void* ctx, uint32_t window_id, int state, const char* key,
+              const char* code, uint32_t modifiers, bool repeat);
+  void (*click)(void* ctx, uint32_t window_id, int state, int button, double x,
+                double y, uint32_t modifiers, int32_t click_count);
+  void (*move)(void* ctx, uint32_t window_id, double x, double y,
+               uint32_t modifiers);
+  void (*wheel)(void* ctx, uint32_t window_id, double delta_x, double delta_y,
+                double x, double y, uint32_t modifiers, int32_t delta_mode);
+  void (*enter_leave)(void* ctx, uint32_t window_id, int entered, double x,
+                      double y, uint32_t modifiers);
+  void* ctx;
+};
+
+// Test-only. Posts `event` through `sink`. Thin path: already-DOM values,
+// click_count 1. Returns false on a null event or unknown kind.
+bool TestInjectInput(uint32_t window_id, const laufey_test_input_t* event,
+                     const TestInjectSink& sink);
+
 }  // namespace laufey_common
 
 #endif  // LAUFEY_BACKEND_COMMON_H_

--- a/backend-common/src/keymap_mac.mm
+++ b/backend-common/src/keymap_mac.mm
@@ -106,6 +106,7 @@ std::string NSEventKeyToCode(unsigned short keyCode) {
     case 50: return "Backquote";
     case 51: return "Backspace";
     case 53: return "Escape";
+    case 54: return "MetaRight";
     case 55: return "MetaLeft";
     case 56: return "ShiftLeft";
     case 57: return "CapsLock";

--- a/backend-common/src/test_hooks.cc
+++ b/backend-common/src/test_hooks.cc
@@ -35,24 +35,117 @@ std::map<std::string, MenuClickEntry>& MenuClickMap() {
 
 void RegisterMenuClick(const std::string& id, laufey_menu_click_fn fn,
                        void* data, uint32_t window_id) {
-  if (id.empty() || !fn) return;
+  if (id.empty() || !fn)
+    return;
   std::lock_guard<std::mutex> lock(MenuClickMutex());
   MenuClickMap()[id] = MenuClickEntry{fn, data, window_id};
 }
 
 bool TestClickMenuItem(const char* item_id) {
-  if (!item_id) return false;
+  if (!item_id)
+    return false;
   std::string id(item_id);
   MenuClickEntry entry;
   {
     std::lock_guard<std::mutex> lock(MenuClickMutex());
     auto it = MenuClickMap().find(id);
-    if (it == MenuClickMap().end()) return false;
+    if (it == MenuClickMap().end())
+      return false;
     entry = it->second;
   }
   // Invoke outside the lock: the handler may re-enter the menu system.
   entry.fn(entry.data, entry.window_id, id.c_str());
   return true;
+}
+
+namespace {
+
+std::mutex& InjectMutex() {
+  static std::mutex m;
+  return m;
+}
+
+std::map<uint32_t, uint32_t>& InjectModifiers() {
+  static std::map<uint32_t, uint32_t> m;
+  return m;
+}
+
+void EmitModifierEdges(uint32_t window_id, uint32_t prev, uint32_t next,
+                       const TestInjectSink& sink) {
+  auto edge = [&](uint32_t bit, const char* key, const char* code) {
+    bool was = (prev & bit) != 0;
+    bool now = (next & bit) != 0;
+    if (was == now || !sink.key)
+      return;
+    sink.key(sink.ctx, window_id,
+             now ? LAUFEY_KEY_PRESSED : LAUFEY_KEY_RELEASED, key, code, next,
+             false);
+  };
+  edge(LAUFEY_MOD_SHIFT, "Shift", "ShiftLeft");
+  edge(LAUFEY_MOD_CONTROL, "Control", "ControlLeft");
+  edge(LAUFEY_MOD_ALT, "Alt", "AltLeft");
+  edge(LAUFEY_MOD_META, "Meta", "MetaLeft");
+}
+
+}  // namespace
+
+bool TestInjectInput(uint32_t window_id, const laufey_test_input_t* event,
+                     const TestInjectSink& sink) {
+  if (!event)
+    return false;
+  switch (event->kind) {
+    case LAUFEY_TEST_INPUT_KEY:
+      if (!sink.key)
+        return false;
+      sink.key(sink.ctx, window_id,
+               event->pressed ? LAUFEY_KEY_PRESSED : LAUFEY_KEY_RELEASED,
+               event->key ? event->key : "", event->code ? event->code : "",
+               event->modifiers, event->repeat);
+      return true;
+    case LAUFEY_TEST_INPUT_MOUSE_MOVE:
+      if (!sink.move)
+        return false;
+      sink.move(sink.ctx, window_id, event->x, event->y, event->modifiers);
+      return true;
+    case LAUFEY_TEST_INPUT_MOUSE_BUTTON:
+      if (!sink.click)
+        return false;
+      sink.click(sink.ctx, window_id,
+                 event->pressed ? LAUFEY_MOUSE_PRESSED : LAUFEY_MOUSE_RELEASED,
+                 event->button, event->x, event->y, event->modifiers, 1);
+      return true;
+    case LAUFEY_TEST_INPUT_WHEEL:
+      if (!sink.wheel)
+        return false;
+      sink.wheel(sink.ctx, window_id, event->delta_x, event->delta_y, event->x,
+                 event->y, event->modifiers, event->delta_mode);
+      return true;
+    case LAUFEY_TEST_INPUT_CURSOR_ENTER:
+      if (!sink.enter_leave)
+        return false;
+      sink.enter_leave(sink.ctx, window_id, 1, event->x, event->y,
+                       event->modifiers);
+      return true;
+    case LAUFEY_TEST_INPUT_CURSOR_LEAVE:
+      if (!sink.enter_leave)
+        return false;
+      sink.enter_leave(sink.ctx, window_id, 0, event->x, event->y,
+                       event->modifiers);
+      return true;
+    case LAUFEY_TEST_INPUT_MODIFIERS: {
+      uint32_t prev = 0;
+      {
+        std::lock_guard<std::mutex> lock(InjectMutex());
+        auto& slot = InjectModifiers()[window_id];
+        prev = slot;
+        slot = event->modifiers;
+      }
+      EmitModifierEdges(window_id, prev, event->modifiers, sink);
+      return true;
+    }
+    default:
+      return false;
+  }
 }
 
 }  // namespace laufey_common

--- a/backend-winit-common/Cargo.toml
+++ b/backend-winit-common/Cargo.toml
@@ -23,4 +23,4 @@ block2 = "0.6"
 dispatch2 = "0.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_System_Registry"] }
+windows-sys = { version = "0.61", features = ["Win32_System_Registry", "Win32_UI_HiDpi"] }

--- a/backend-winit-common/Cargo.toml
+++ b/backend-winit-common/Cargo.toml
@@ -16,11 +16,17 @@ notify-rust = "4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
-objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSAppearance", "NSDockTile", "NSMenu", "NSMenuItem", "NSResponder", "NSRunningApplication"] }
+objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSAppearance", "NSDockTile", "NSMenu", "NSMenuItem", "NSResponder", "NSRunningApplication", "NSWindow"] }
 objc2-foundation = { version = "0.3", features = ["NSString", "NSThread", "NSBundle", "NSError"] }
 objc2-user-notifications = "0.3"
 block2 = "0.6"
 dispatch2 = "0.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_System_Registry", "Win32_UI_HiDpi"] }
+windows-sys = { version = "0.61", features = [
+  "Win32_System_Registry",
+  "Win32_UI_HiDpi",
+  "Win32_Foundation",
+  "Win32_Graphics_Gdi",
+  "Win32_UI_WindowsAndMessaging",
+] }

--- a/backend-winit-common/src/lib.rs
+++ b/backend-winit-common/src/lib.rs
@@ -3684,13 +3684,19 @@ pub fn modifiers_to_laufey(mods: winit::keyboard::ModifiersState) -> u32 {
   flags
 }
 
-/// Convert a winit logical key to its W3C UI Events `key` string representation.
+/// Convert a winit logical key to its W3C UI Events `key` string.
 pub fn winit_key_to_string(key: &winit::keyboard::Key) -> String {
+  use winit::keyboard::{Key, NamedKey};
   match key {
-    winit::keyboard::Key::Character(c) => c.to_string(),
-    winit::keyboard::Key::Named(named) => format!("{named:?}"),
-    winit::keyboard::Key::Unidentified(_) => "Unidentified".to_string(),
-    winit::keyboard::Key::Dead(c) => {
+    Key::Character(c) => c.to_string(),
+    // Debug is `Super` / `Space`; the Web `key` values are `Meta` and U+0020.
+    Key::Named(NamedKey::Super) | Key::Named(NamedKey::Meta) => {
+      "Meta".to_string()
+    }
+    Key::Named(NamedKey::Space) => " ".to_string(),
+    Key::Named(named) => format!("{named:?}"),
+    Key::Unidentified(_) => "Unidentified".to_string(),
+    Key::Dead(c) => {
       if let Some(ch) = c {
         format!("Dead({ch})")
       } else {
@@ -3700,11 +3706,149 @@ pub fn winit_key_to_string(key: &winit::keyboard::Key) -> String {
   }
 }
 
-/// Convert a winit physical key to its W3C UI Events `code` string representation.
+/// Convert a winit physical key to its W3C UI Events `code` string.
 pub fn winit_code_to_string(physical: &winit::keyboard::PhysicalKey) -> String {
+  use winit::keyboard::{KeyCode, PhysicalKey};
   match physical {
-    winit::keyboard::PhysicalKey::Code(code) => format!("{code:?}"),
-    winit::keyboard::PhysicalKey::Unidentified(_) => "Unidentified".to_string(),
+    PhysicalKey::Code(KeyCode::SuperLeft) => "MetaLeft".to_string(),
+    PhysicalKey::Code(KeyCode::SuperRight) => "MetaRight".to_string(),
+    PhysicalKey::Code(code) => format!("{code:?}"),
+    PhysicalKey::Unidentified(_) => "Unidentified".to_string(),
+  }
+}
+
+pub fn is_modifier_named_key(key: &winit::keyboard::Key) -> bool {
+  use winit::keyboard::{Key, NamedKey};
+  matches!(
+    key,
+    Key::Named(
+      NamedKey::Shift
+        | NamedKey::Control
+        | NamedKey::Alt
+        | NamedKey::AltGraph
+        | NamedKey::Super
+        | NamedKey::Meta
+        | NamedKey::Hyper
+    )
+  )
+}
+
+/// Modifier bits that changed between two `ModifiersChanged` events.
+/// macOS winit often has no `KeyboardInput` for Shift / Control / Alt / Meta;
+/// CEF and WebView still emit `keydown` / `keyup`.
+pub fn modifier_key_edges(
+  prev: &winit::event::Modifiers,
+  next: &winit::event::Modifiers,
+) -> Vec<(bool, &'static str, &'static str)> {
+  use winit::keyboard::ModifiersKeyState::Pressed;
+  let mut out = Vec::new();
+  let push = |out: &mut Vec<_>,
+              was: bool,
+              now: bool,
+              prev_l: winit::keyboard::ModifiersKeyState,
+              prev_r: winit::keyboard::ModifiersKeyState,
+              next_l: winit::keyboard::ModifiersKeyState,
+              next_r: winit::keyboard::ModifiersKeyState,
+              key: &'static str,
+              left: &'static str,
+              right: &'static str| {
+    if was == now {
+      return;
+    }
+    let code = if now {
+      if next_r == Pressed && next_l != Pressed {
+        right
+      } else {
+        left
+      }
+    } else if prev_r == Pressed && prev_l != Pressed {
+      right
+    } else {
+      left
+    };
+    out.push((now, key, code));
+  };
+  push(
+    &mut out,
+    prev.state().shift_key(),
+    next.state().shift_key(),
+    prev.lshift_state(),
+    prev.rshift_state(),
+    next.lshift_state(),
+    next.rshift_state(),
+    "Shift",
+    "ShiftLeft",
+    "ShiftRight",
+  );
+  push(
+    &mut out,
+    prev.state().control_key(),
+    next.state().control_key(),
+    prev.lcontrol_state(),
+    prev.rcontrol_state(),
+    next.lcontrol_state(),
+    next.rcontrol_state(),
+    "Control",
+    "ControlLeft",
+    "ControlRight",
+  );
+  push(
+    &mut out,
+    prev.state().alt_key(),
+    next.state().alt_key(),
+    prev.lalt_state(),
+    prev.ralt_state(),
+    next.lalt_state(),
+    next.ralt_state(),
+    "Alt",
+    "AltLeft",
+    "AltRight",
+  );
+  push(
+    &mut out,
+    prev.state().super_key(),
+    next.state().super_key(),
+    prev.lsuper_state(),
+    prev.rsuper_state(),
+    next.lsuper_state(),
+    next.rsuper_state(),
+    "Meta",
+    "MetaLeft",
+    "MetaRight",
+  );
+  out
+}
+
+pub fn dispatch_raw_keyboard_event(
+  handlers: &EventHandlers,
+  window_id: u32,
+  pressed: bool,
+  key: &str,
+  code: &str,
+  modifiers: winit::keyboard::ModifiersState,
+  repeat: bool,
+) {
+  let handler = handlers.keyboard_handler.lock().unwrap();
+  if let Some((cb, user_data)) = *handler {
+    let state = if pressed {
+      LAUFEY_KEY_PRESSED
+    } else {
+      LAUFEY_KEY_RELEASED
+    };
+    let mods = modifiers_to_laufey(modifiers);
+    let c_key = std::ffi::CString::new(key).unwrap_or_default();
+    let c_code = std::ffi::CString::new(code).unwrap_or_default();
+    unsafe {
+      cb(
+        user_data as *mut c_void,
+        window_id,
+        state,
+        c_key.as_ptr(),
+        c_code.as_ptr(),
+        mods,
+        repeat,
+      );
+    }
   }
 }
 
@@ -3715,31 +3859,17 @@ pub fn dispatch_keyboard_event(
   key_event: &winit::event::KeyEvent,
   modifiers: winit::keyboard::ModifiersState,
 ) {
-  let handler = handlers.keyboard_handler.lock().unwrap();
-  if let Some((cb, user_data)) = *handler {
-    let state = match key_event.state {
-      winit::event::ElementState::Pressed => LAUFEY_KEY_PRESSED,
-      winit::event::ElementState::Released => LAUFEY_KEY_RELEASED,
-    };
-    let key_str = winit_key_to_string(&key_event.logical_key);
-    let code_str = winit_code_to_string(&key_event.physical_key);
-    let mods = modifiers_to_laufey(modifiers);
-
-    let c_key = std::ffi::CString::new(key_str).unwrap_or_default();
-    let c_code = std::ffi::CString::new(code_str).unwrap_or_default();
-
-    unsafe {
-      cb(
-        user_data as *mut c_void,
-        window_id,
-        state,
-        c_key.as_ptr(),
-        c_code.as_ptr(),
-        mods,
-        key_event.repeat,
-      );
-    }
-  }
+  let key_str = winit_key_to_string(&key_event.logical_key);
+  let code_str = winit_code_to_string(&key_event.physical_key);
+  dispatch_raw_keyboard_event(
+    handlers,
+    window_id,
+    key_event.state == winit::event::ElementState::Pressed,
+    &key_str,
+    &code_str,
+    modifiers,
+    key_event.repeat,
+  );
 }
 
 /// Convert a winit mouse button to a LAUFEY mouse button constant.
@@ -4312,6 +4442,42 @@ mod mouse_tests {
     assert_eq!(physical_size_to_logical_i32(960, 640, 2.0), (480, 320));
     assert_eq!(physical_size_to_logical_i32(960, 720, 1.5), (640, 480));
     assert_eq!(physical_size_to_logical_i32(480, 320, 1.0), (480, 320));
+  }
+
+  #[test]
+  fn named_keys_use_w3c_key_values() {
+    use winit::keyboard::{Key, NamedKey};
+    assert_eq!(winit_key_to_string(&Key::Named(NamedKey::Super)), "Meta");
+    assert_eq!(winit_key_to_string(&Key::Named(NamedKey::Space)), " ");
+    assert_eq!(winit_key_to_string(&Key::Named(NamedKey::Shift)), "Shift");
+  }
+
+  #[test]
+  fn super_codes_use_w3c_meta() {
+    use winit::keyboard::{KeyCode, PhysicalKey};
+    assert_eq!(
+      winit_code_to_string(&PhysicalKey::Code(KeyCode::SuperLeft)),
+      "MetaLeft"
+    );
+    assert_eq!(
+      winit_code_to_string(&PhysicalKey::Code(KeyCode::ShiftLeft)),
+      "ShiftLeft"
+    );
+  }
+
+  #[test]
+  fn modifier_edges_emit_shift_down_and_up() {
+    let prev = winit::event::Modifiers::default();
+    let next: winit::event::Modifiers =
+      winit::keyboard::ModifiersState::SHIFT.into();
+    assert_eq!(
+      modifier_key_edges(&prev, &next),
+      vec![(true, "Shift", "ShiftLeft")]
+    );
+    assert_eq!(
+      modifier_key_edges(&next, &prev),
+      vec![(false, "Shift", "ShiftLeft")]
+    );
   }
 
   #[test]

--- a/backend-winit-common/src/lib.rs
+++ b/backend-winit-common/src/lib.rs
@@ -574,7 +574,41 @@ pub struct LaufeyBackendApi {
   // --- Content-view origin (API >= 35) ---
   pub get_window_inner_position:
     Option<unsafe extern "C" fn(*mut c_void, u32, *mut c_int, *mut c_int)>,
+
+  // --- Outer window size (API >= 35) ---
+  pub get_window_outer_size:
+    Option<unsafe extern "C" fn(*mut c_void, u32, *mut c_int, *mut c_int)>,
+
+  // --- Test input injection (API >= 35) ---
+  pub test_inject_input: Option<
+    unsafe extern "C" fn(*mut c_void, u32, *const LaufeyTestInput) -> bool,
+  >,
 }
+
+/// Mirrors `laufey_test_input_t` in laufey.h.
+#[repr(C)]
+pub struct LaufeyTestInput {
+  pub kind: c_int,
+  pub modifiers: u32,
+  pub key: *const c_char,
+  pub code: *const c_char,
+  pub pressed: bool,
+  pub repeat: bool,
+  pub button: c_int,
+  pub x: f64,
+  pub y: f64,
+  pub delta_x: f64,
+  pub delta_y: f64,
+  pub delta_mode: c_int,
+}
+
+pub const LAUFEY_TEST_INPUT_KEY: c_int = 0;
+pub const LAUFEY_TEST_INPUT_MOUSE_MOVE: c_int = 1;
+pub const LAUFEY_TEST_INPUT_MOUSE_BUTTON: c_int = 2;
+pub const LAUFEY_TEST_INPUT_WHEEL: c_int = 3;
+pub const LAUFEY_TEST_INPUT_CURSOR_ENTER: c_int = 4;
+pub const LAUFEY_TEST_INPUT_CURSOR_LEAVE: c_int = 5;
+pub const LAUFEY_TEST_INPUT_MODIFIERS: c_int = 6;
 
 unsafe impl Send for LaufeyBackendApi {}
 
@@ -1220,6 +1254,10 @@ pub fn create_api_base() -> LaufeyBackendApi {
     get_window_scale_factor: None,
     // Content-view origin (API >= 35): filled by fill_common_api.
     get_window_inner_position: None,
+    // Outer window size (API >= 35): filled by fill_common_api.
+    get_window_outer_size: None,
+    // Test input injection (API >= 35): filled by fill_common_api.
+    test_inject_input: None,
   }
 }
 
@@ -1749,12 +1787,23 @@ pub struct WindowState {
   /// Backs `get_window_size` so it never reports 0x0 (which produced a 0x0 wgpu
   /// surface) and matches CEF / WebView / `set_size`.
   pub current_size: Mutex<Option<(i32, i32)>>,
+  /// Chrome-inclusive size in the same DIP space, seeded from `outer_size()`
+  /// and refreshed on resize. Backs `get_window_outer_size`.
+  pub current_outer_size: Mutex<Option<(i32, i32)>>,
   /// `window.scale_factor()`, seeded at create and refreshed on
   /// `ScaleFactorChanged`. Backs `get_window_scale_factor`.
   pub current_scale: Mutex<f64>,
   /// Content-view top-left in screen DIP. `getPosition` is the frame;
   /// this plus `clientX`/`clientY` is `MouseEvent.screenX`/`screenY`.
   pub current_inner_position: Mutex<Option<(i32, i32)>>,
+  /// Authoritative frame top-left in screen DIP, seeded at create and
+  /// refreshed on `Moved`. Backs `get_window_position`.
+  ///
+  /// Distinct from `pending_position`, which is a one-shot *requested*
+  /// position consumed when applied — reading that back reported (0, 0) once
+  /// the request had been handled, and reported the request rather than the
+  /// real origin where the OS placed the window somewhere else.
+  pub current_position: Mutex<Option<(i32, i32)>>,
   pub pending_position: Mutex<Option<(i32, i32)>>,
   pub pending_resizable: Mutex<Option<bool>>,
   pub pending_always_on_top: Mutex<Option<bool>>,
@@ -1775,6 +1824,20 @@ pub struct WindowState {
   pub last_press_button: Mutex<Option<winit::event::MouseButton>>,
   pub last_press_position: Mutex<Option<(f64, f64)>>,
   pub click_count: Mutex<i32>,
+  /// Last modifiers applied by `test_inject_input`. Real
+  /// `ModifiersChanged` lives on the winit window map; the hook keeps its
+  /// own so a MODIFIERS event can emit the same edges.
+  pub inject_modifiers: Mutex<winit::event::Modifiers>,
+  /// False until the creation-time `Resized` burst has been drained.
+  ///
+  /// Creating a window makes the OS emit several `Resized` events describing
+  /// intermediate sizes (on Windows: a default size, then the DIP-adjusted
+  /// one, then the requested one). They are all *different*, so the
+  /// same-size check cannot collapse them and the app would see `resize` fire
+  /// for sizes it never asked for. Nothing is dispatched while this is false;
+  /// `settle_creation_geometry` re-syncs from the real window and arms it
+  /// once the event loop first goes idle.
+  pub resize_reporting_armed: Mutex<bool>,
 }
 
 impl WindowState {
@@ -1783,8 +1846,10 @@ impl WindowState {
       pending_title: Mutex::new(None),
       pending_size: Mutex::new(None),
       current_size: Mutex::new(None),
+      current_outer_size: Mutex::new(None),
       current_scale: Mutex::new(primary_scale_hint()),
       current_inner_position: Mutex::new(None),
+      current_position: Mutex::new(None),
       pending_position: Mutex::new(None),
       pending_resizable: Mutex::new(None),
       pending_always_on_top: Mutex::new(None),
@@ -1800,6 +1865,8 @@ impl WindowState {
       last_press_button: Mutex::new(None),
       last_press_position: Mutex::new(None),
       click_count: Mutex::new(0),
+      inject_modifiers: Mutex::new(winit::event::Modifiers::default()),
+      resize_reporting_armed: Mutex::new(false),
     }
   }
 }
@@ -2123,6 +2190,44 @@ macro_rules! define_common_backend_fns {
       }
     }
 
+    unsafe extern "C" fn backend_get_window_outer_size(
+      _data: *mut ::std::ffi::c_void,
+      window_id: u32,
+      width: *mut ::std::ffi::c_int,
+      height: *mut ::std::ffi::c_int,
+    ) {
+      let mut found = false;
+      if let Some(state) = <$B as $crate::BackendAccess>::get() {
+        if let Some(()) = state.common().with_window(window_id, |ws| {
+          let size = (*ws.current_outer_size.lock().unwrap()).or_else(|| {
+            let inner = (*ws.current_size.lock().unwrap())
+              .or(*ws.pending_size.lock().unwrap())?;
+            let (dw, dh) =
+              $crate::frame_extent_hint(*ws.pending_flags.lock().unwrap());
+            Some((inner.0 + dw, inner.1 + dh))
+          });
+          if let Some((w, h)) = size {
+            if !width.is_null() {
+              *width = w;
+            }
+            if !height.is_null() {
+              *height = h;
+            }
+          }
+        }) {
+          found = true;
+        }
+      }
+      if !found {
+        if !width.is_null() {
+          *width = 0;
+        }
+        if !height.is_null() {
+          *height = 0;
+        }
+      }
+    }
+
     unsafe extern "C" fn backend_get_window_scale_factor(
       _data: *mut ::std::ffi::c_void,
       window_id: u32,
@@ -2153,9 +2258,22 @@ macro_rules! define_common_backend_fns {
           if let Some((ix, iy)) = *ws.current_inner_position.lock().unwrap() {
             px = ix;
             py = iy;
-          } else if let Some((ox, oy)) = *ws.pending_position.lock().unwrap() {
-            px = ox;
-            py = oy;
+          } else if let Some((ox, oy)) = (*ws.current_position.lock().unwrap())
+            .or(*ws.pending_position.lock().unwrap())
+          {
+            // No content origin to read: either the window does not exist
+            // yet, or the platform doesn't report one — winit answers
+            // `NotSupportedError` on Wayland and on X11 under some
+            // compositors. Offset the frame origin by what the chrome
+            // measures rather than reporting a point on the title bar.
+            //
+            // `current_position` has to come first: `pending_position` is a
+            // request consumed once applied, so on those platforms this fell
+            // through to nothing and reported (0, 0) after the first move.
+            let (dx, dy) =
+              $crate::frame_offset_hint(*ws.pending_flags.lock().unwrap());
+            px = ox + dx;
+            py = oy + dy;
           }
         });
       }
@@ -2194,7 +2312,11 @@ macro_rules! define_common_backend_fns {
       let mut found = false;
       if let Some(state) = <$B as $crate::BackendAccess>::get() {
         if let Some(()) = state.common().with_window(window_id, |ws| {
-          if let Some((px, py)) = *ws.pending_position.lock().unwrap() {
+          // Prefer the real origin; fall back to a request that has not been
+          // applied yet, which is all there is before the window exists.
+          let pos = (*ws.current_position.lock().unwrap())
+            .or(*ws.pending_position.lock().unwrap());
+          if let Some((px, py)) = pos {
             if !x.is_null() {
               *x = px;
             }
@@ -2628,6 +2750,32 @@ macro_rules! define_common_backend_fns {
       $crate::dispatch_menu_click_by_id(&id)
     }
 
+    unsafe extern "C" fn backend_test_inject_input(
+      _data: *mut ::std::ffi::c_void,
+      window_id: u32,
+      event: *const $crate::LaufeyTestInput,
+    ) -> bool {
+      if event.is_null() {
+        return false;
+      }
+      let event = unsafe { &*event };
+      if let Some(state) = <$B as $crate::BackendAccess>::get() {
+        state
+          .common()
+          .with_window(window_id, |ws| {
+            $crate::inject_test_input(
+              &state.common().handlers,
+              ws,
+              window_id,
+              event,
+            )
+          })
+          .unwrap_or(false)
+      } else {
+        false
+      }
+    }
+
     unsafe extern "C" fn backend_set_application_menu(
       _data: *mut ::std::ffi::c_void,
       window_id: u32,
@@ -3007,6 +3155,7 @@ macro_rules! fill_common_api {
     $api.quit = Some(backend_quit);
     $api.set_window_size = Some(backend_set_window_size);
     $api.get_window_size = Some(backend_get_window_size);
+    $api.get_window_outer_size = Some(backend_get_window_outer_size);
     $api.get_window_scale_factor = Some(backend_get_window_scale_factor);
     $api.get_window_inner_position = Some(backend_get_window_inner_position);
     $api.set_window_position = Some(backend_set_window_position);
@@ -3064,6 +3213,7 @@ macro_rules! fill_common_api {
     $api.test_click_menu_item = Some(backend_test_click_menu_item);
     $api.test_trigger_close_requested =
       Some(backend_test_trigger_close_requested);
+    $api.test_inject_input = Some(backend_test_inject_input);
   };
 }
 
@@ -3103,6 +3253,10 @@ pub fn handle_common_event<B: BackendAccess>(
         state.common().with_window(window_id, |ws| {
           if let Some((x, y)) = ws.pending_position.lock().unwrap().take() {
             window.set_outer_position(LogicalPosition::new(x, y));
+            // Reflect the move now rather than waiting for `Moved`, so a read
+            // straight after `set_position` doesn't report the old origin.
+            // `Moved` corrects this if the OS placed it elsewhere.
+            *ws.current_position.lock().unwrap() = Some((x, y));
           }
         });
       }
@@ -3300,33 +3454,190 @@ pub fn physical_pos_to_logical_i32(
 /// Best-effort scale before the winit `Window` exists. JS may read
 /// `devicePixelRatio` from the constructor, which runs before `CreateWindow`
 /// is processed.
+#[cfg(target_os = "macos")]
 pub fn primary_scale_hint() -> f64 {
-  #[cfg(target_os = "macos")]
-  {
-    use objc2::msg_send;
-    use objc2::runtime::{AnyClass, AnyObject};
-    let Some(cls) = AnyClass::get(c"NSScreen") else {
-      return 1.0;
-    };
-    let screen: Option<&AnyObject> = unsafe { msg_send![cls, mainScreen] };
-    let Some(screen) = screen else {
-      return 1.0;
-    };
-    let scale: f64 = unsafe { msg_send![screen, backingScaleFactor] };
-    return if scale > 0.0 { scale } else { 1.0 };
+  use objc2::msg_send;
+  use objc2::runtime::{AnyClass, AnyObject};
+  let Some(cls) = AnyClass::get(c"NSScreen") else {
+    return 1.0;
+  };
+  let screen: Option<&AnyObject> = unsafe { msg_send![cls, mainScreen] };
+  let Some(screen) = screen else {
+    return 1.0;
+  };
+  let scale: f64 = unsafe { msg_send![screen, backingScaleFactor] };
+  if scale > 0.0 {
+    scale
+  } else {
+    1.0
   }
-  #[cfg(target_os = "windows")]
-  {
-    windows_sys::Win32::UI::HiDpi::GetDpiForSystem() as f64 / 96.0
+}
+
+#[cfg(target_os = "windows")]
+pub fn primary_scale_hint() -> f64 {
+  let dpi = unsafe { windows_sys::Win32::UI::HiDpi::GetDpiForSystem() };
+  if dpi > 0 {
+    dpi as f64 / 96.0
+  } else {
+    1.0
   }
-  #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
-  {
-    std::env::var("GDK_SCALE")
-      .ok()
-      .and_then(|s| s.parse().ok())
-      .filter(|s: &f64| *s > 0.0)
-      .unwrap_or(1.0)
+}
+
+#[cfg(target_os = "linux")]
+pub fn primary_scale_hint() -> f64 {
+  std::env::var("GDK_SCALE")
+    .ok()
+    .and_then(|s| s.parse().ok())
+    .filter(|s: &f64| *s > 0.0)
+    .unwrap_or(1.0)
+}
+
+#[cfg(not(any(
+  target_os = "macos",
+  target_os = "windows",
+  target_os = "linux"
+)))]
+pub fn primary_scale_hint() -> f64 {
+  1.0
+}
+
+/// Best-effort title-bar / border offset before the winit `Window` exists, in
+/// logical pixels.
+///
+/// `getInnerPosition()` is the content-view origin, but the window is created
+/// asynchronously and JS can read it straight after the constructor. Falling
+/// back to the frame origin reported a point on the title bar; ask the OS what
+/// the chrome will measure instead. `flags` are the creation-time
+/// `LAUFEY_WINDOW_FLAG_*` bits — a frameless window has no chrome to offset.
+#[cfg(target_os = "macos")]
+pub fn frame_offset_hint(flags: u32) -> (i32, i32) {
+  if flags & LAUFEY_WINDOW_FLAG_FRAMELESS != 0 {
+    return (0, 0);
   }
+  use objc2_app_kit::{NSWindow, NSWindowStyleMask};
+  use objc2_foundation::{MainThreadMarker, NSPoint, NSRect, NSSize};
+  let mtm = unsafe { MainThreadMarker::new_unchecked() };
+  let style = NSWindowStyleMask::Titled
+    | NSWindowStyleMask::Closable
+    | NSWindowStyleMask::Miniaturizable
+    | NSWindowStyleMask::Resizable;
+  let frame = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(100.0, 100.0));
+  let content = NSWindow::contentRectForFrameRect_styleMask(frame, style, mtm);
+  let dx = (content.origin.x - frame.origin.x).round() as i32;
+  let dy = (frame.size.height - content.size.height).round() as i32;
+  (dx.max(0), dy.max(0))
+}
+
+#[cfg(target_os = "windows")]
+pub fn frame_offset_hint(flags: u32) -> (i32, i32) {
+  if flags & LAUFEY_WINDOW_FLAG_FRAMELESS != 0 {
+    return (0, 0);
+  }
+  use windows_sys::Win32::Foundation::RECT;
+  use windows_sys::Win32::UI::HiDpi::{
+    AdjustWindowRectExForDpi, GetDpiForSystem,
+  };
+  use windows_sys::Win32::UI::WindowsAndMessaging::{
+    WS_EX_WINDOWEDGE, WS_OVERLAPPEDWINDOW,
+  };
+  let dpi = unsafe { GetDpiForSystem() };
+  if dpi == 0 {
+    return (0, 0);
+  }
+  // Adjusting an empty client rect leaves the chrome thickness in the
+  // (now negative) left/top corner.
+  let mut rect = RECT {
+    left: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+  };
+  let ok = unsafe {
+    AdjustWindowRectExForDpi(
+      &mut rect,
+      WS_OVERLAPPEDWINDOW,
+      0,
+      WS_EX_WINDOWEDGE,
+      dpi,
+    )
+  };
+  if ok == 0 {
+    return (0, 0);
+  }
+  let scale = dpi as f64 / 96.0;
+  physical_pos_to_logical_i32(-rect.left, -rect.top, scale)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+pub fn frame_offset_hint(_flags: u32) -> (i32, i32) {
+  // The frame offset is the compositor's business.
+  (0, 0)
+}
+
+/// Extra DIP to add to the content size to get the chrome-inclusive size
+/// before the winit `Window` exists.
+#[cfg(target_os = "macos")]
+pub fn frame_extent_hint(flags: u32) -> (i32, i32) {
+  if flags & LAUFEY_WINDOW_FLAG_FRAMELESS != 0 {
+    return (0, 0);
+  }
+  use objc2_app_kit::{NSWindow, NSWindowStyleMask};
+  use objc2_foundation::{MainThreadMarker, NSPoint, NSRect, NSSize};
+  let mtm = unsafe { MainThreadMarker::new_unchecked() };
+  let style = NSWindowStyleMask::Titled
+    | NSWindowStyleMask::Closable
+    | NSWindowStyleMask::Miniaturizable
+    | NSWindowStyleMask::Resizable;
+  let content = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(100.0, 100.0));
+  let frame = NSWindow::frameRectForContentRect_styleMask(content, style, mtm);
+  let dw = (frame.size.width - content.size.width).round() as i32;
+  let dh = (frame.size.height - content.size.height).round() as i32;
+  (dw.max(0), dh.max(0))
+}
+
+#[cfg(target_os = "windows")]
+pub fn frame_extent_hint(flags: u32) -> (i32, i32) {
+  if flags & LAUFEY_WINDOW_FLAG_FRAMELESS != 0 {
+    return (0, 0);
+  }
+  use windows_sys::Win32::Foundation::RECT;
+  use windows_sys::Win32::UI::HiDpi::{
+    AdjustWindowRectExForDpi, GetDpiForSystem,
+  };
+  use windows_sys::Win32::UI::WindowsAndMessaging::{
+    WS_EX_WINDOWEDGE, WS_OVERLAPPEDWINDOW,
+  };
+  let dpi = unsafe { GetDpiForSystem() };
+  if dpi == 0 {
+    return (0, 0);
+  }
+  let mut rect = RECT {
+    left: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+  };
+  let ok = unsafe {
+    AdjustWindowRectExForDpi(
+      &mut rect,
+      WS_OVERLAPPEDWINDOW,
+      0,
+      WS_EX_WINDOWEDGE,
+      dpi,
+    )
+  };
+  if ok == 0 {
+    return (0, 0);
+  }
+  let scale = dpi as f64 / 96.0;
+  let extra_w = (rect.right - rect.left).max(0) as u32;
+  let extra_h = (rect.bottom - rect.top).max(0) as u32;
+  physical_size_to_logical_i32(extra_w, extra_h, scale)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+pub fn frame_extent_hint(_flags: u32) -> (i32, i32) {
+  (0, 0)
 }
 
 pub fn physical_pos_to_logical_f64(
@@ -3398,6 +3709,23 @@ pub fn apply_pending_post_create(ws: &WindowState, window: &Window) {
     *ws.current_inner_position.lock().unwrap() =
       Some(physical_pos_to_logical_i32(inner.x, inner.y, scale));
   }
+  // Same for the frame origin. `get_window_position` reads `pending_position`,
+  // which is only ever a *requested* position, so a window the OS placed
+  // itself reported (0, 0) until the first `Moved` arrived; and where the OS
+  // adjusted a requested position, it reported the request rather than where
+  // the window actually is.
+  // Same for the frame origin, so `get_window_position` has an authoritative
+  // value that does not depend on a request having been made.
+  if let Ok(outer) = window.outer_position() {
+    *ws.current_position.lock().unwrap() =
+      Some(physical_pos_to_logical_i32(outer.x, outer.y, scale));
+  }
+  let outer_size = window.outer_size();
+  if outer_size.width > 0 && outer_size.height > 0 {
+    *ws.current_outer_size.lock().unwrap() = Some(
+      physical_size_to_logical_i32(outer_size.width, outer_size.height, scale),
+    );
+  }
 
   if let Some(true) = *ws.pending_always_on_top.lock().unwrap() {
     window.set_window_level(WindowLevel::AlwaysOnTop);
@@ -3410,6 +3738,62 @@ pub fn apply_pending_post_create(ws: &WindowState, window: &Window) {
   if *ws.pending_flags.lock().unwrap() & LAUFEY_WINDOW_FLAG_NO_ACTIVATE != 0 {
     window.set_window_level(WindowLevel::AlwaysOnTop);
   }
+}
+
+/// Close out the creation-time `Resized` burst, called once the event loop
+/// first goes idle after the window was built.
+///
+/// Re-syncs the cached geometry from the real window and arms resize
+/// reporting. Re-syncing matters as much as arming: a stale `Resized` that
+/// slips past the first idle then carries a size equal to the one already
+/// cached, so the same-size check in the `Resized` handler drops it instead of
+/// reporting a size the window no longer has.
+///
+/// Returns true the first time it arms (so callers can skip repeat work).
+pub fn settle_creation_geometry(ws: &WindowState, window: &Window) -> bool {
+  let scale = window.scale_factor();
+  let size = window.inner_size();
+  let size = (size.width > 0 && size.height > 0)
+    .then(|| physical_size_to_logical_i32(size.width, size.height, scale));
+  let inner = window
+    .inner_position()
+    .ok()
+    .map(|p| physical_pos_to_logical_i32(p.x, p.y, scale));
+  let armed = arm_resize_reporting(ws, size, scale, inner);
+  let outer = window.outer_size();
+  if outer.width > 0 && outer.height > 0 {
+    *ws.current_outer_size.lock().unwrap() = Some(
+      physical_size_to_logical_i32(outer.width, outer.height, scale),
+    );
+  }
+  armed
+}
+
+/// The state machine behind [`settle_creation_geometry`], split out so the
+/// arm-once semantics are testable without a real `Window` (creating one
+/// needs a display server).
+///
+/// `size` and `inner` are already in logical pixels, and are skipped when the
+/// platform could not supply them.
+pub fn arm_resize_reporting(
+  ws: &WindowState,
+  size: Option<(i32, i32)>,
+  scale: f64,
+  inner: Option<(i32, i32)>,
+) -> bool {
+  let mut armed = ws.resize_reporting_armed.lock().unwrap();
+  if *armed {
+    return false;
+  }
+  if let Some(size) = size {
+    *ws.current_size.lock().unwrap() = Some(size);
+    *ws.current_scale.lock().unwrap() = scale;
+  }
+  if let Some(inner) = inner {
+    *ws.current_inner_position.lock().unwrap() = Some(inner);
+  }
+  *armed = true;
+  true
 }
 
 // --- Native dialog implementation ---
@@ -3666,6 +4050,26 @@ pub const LAUFEY_MOUSE_BUTTON_FORWARD: c_int = 4;
 pub const LAUFEY_MOUSE_PRESSED: c_int = 0;
 pub const LAUFEY_MOUSE_RELEASED: c_int = 1;
 
+/// Convert a LAUFEY modifier bitmask to winit's `ModifiersState`.
+pub fn laufey_to_modifiers_state(
+  flags: u32,
+) -> winit::keyboard::ModifiersState {
+  let mut s = winit::keyboard::ModifiersState::empty();
+  if flags & LAUFEY_MOD_SHIFT != 0 {
+    s |= winit::keyboard::ModifiersState::SHIFT;
+  }
+  if flags & LAUFEY_MOD_CONTROL != 0 {
+    s |= winit::keyboard::ModifiersState::CONTROL;
+  }
+  if flags & LAUFEY_MOD_ALT != 0 {
+    s |= winit::keyboard::ModifiersState::ALT;
+  }
+  if flags & LAUFEY_MOD_META != 0 {
+    s |= winit::keyboard::ModifiersState::SUPER;
+  }
+  s
+}
+
 /// Convert winit modifier state to LAUFEY modifier bitmask.
 pub fn modifiers_to_laufey(mods: winit::keyboard::ModifiersState) -> u32 {
   let mut flags = 0u32;
@@ -3919,6 +4323,65 @@ pub fn next_click_count(
   }
 }
 
+/// Re-read the pointer from the OS into `cursor_position`, in logical pixels.
+///
+/// winit's `MouseInput` carries no coordinates, so button events are reported
+/// at the last position `CursorMoved` cached. On Windows that is not
+/// reliable: `WM_*BUTTONDOWN` is a genuine queued message while `WM_MOUSEMOVE`
+/// is synthesized from the current pointer only when the queue holds nothing
+/// else, so a press can be dequeued *before* the move that preceded it and
+/// gets reported one position stale. Win32 button messages carry their own
+/// coordinates and browsers use those; the closest equivalent here is to ask
+/// the OS where the pointer is before dispatching.
+///
+/// No-op off Windows, where `CursorMoved` already arrives in order.
+#[cfg(target_os = "macos")]
+pub fn refresh_cursor_position(
+  _ws: &WindowState,
+  _window: &Window,
+  _scale_factor: f64,
+) {
+}
+
+#[cfg(target_os = "windows")]
+pub fn refresh_cursor_position(
+  ws: &WindowState,
+  window: &Window,
+  scale_factor: f64,
+) {
+  use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+  use windows_sys::Win32::Foundation::POINT;
+  use windows_sys::Win32::Graphics::Gdi::ScreenToClient;
+  use windows_sys::Win32::UI::WindowsAndMessaging::GetCursorPos;
+
+  let Ok(handle) = window.window_handle() else {
+    return;
+  };
+  let RawWindowHandle::Win32(win32) = handle.as_raw() else {
+    return;
+  };
+  let hwnd = win32.hwnd.get() as *mut core::ffi::c_void;
+  let mut pt = POINT { x: 0, y: 0 };
+  unsafe {
+    if GetCursorPos(&mut pt) == 0 || ScreenToClient(hwnd, &mut pt) == 0 {
+      return;
+    }
+  }
+  // Client coordinates, so this is already relative to the content view;
+  // a drag past the edge legitimately reports negatives.
+  *ws.cursor_position.lock().unwrap() =
+    physical_pos_to_logical_f64(pt.x as f64, pt.y as f64, scale_factor);
+  *ws.cursor_seen.lock().unwrap() = true;
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+pub fn refresh_cursor_position(
+  _ws: &WindowState,
+  _window: &Window,
+  _scale_factor: f64,
+) {
+}
+
 pub fn dispatch_mouse_click_event(
   handlers: &EventHandlers,
   ws: &WindowState,
@@ -4034,6 +4497,136 @@ pub fn dispatch_wheel_event(
         delta_mode,
       );
     }
+  }
+}
+
+fn c_str_or_empty(p: *const c_char) -> String {
+  if p.is_null() {
+    String::new()
+  } else {
+    unsafe { CStr::from_ptr(p) }.to_string_lossy().into_owned()
+  }
+}
+
+fn is_modifier_key_name(key: &str) -> bool {
+  matches!(key, "Shift" | "Control" | "Alt" | "AltGraph" | "Meta")
+}
+
+fn laufey_button_to_winit(button: c_int) -> Option<winit::event::MouseButton> {
+  match button {
+    LAUFEY_MOUSE_BUTTON_LEFT => Some(winit::event::MouseButton::Left),
+    LAUFEY_MOUSE_BUTTON_RIGHT => Some(winit::event::MouseButton::Right),
+    LAUFEY_MOUSE_BUTTON_MIDDLE => Some(winit::event::MouseButton::Middle),
+    LAUFEY_MOUSE_BUTTON_BACK => Some(winit::event::MouseButton::Back),
+    LAUFEY_MOUSE_BUTTON_FORWARD => Some(winit::event::MouseButton::Forward),
+    _ => None,
+  }
+}
+
+/// Drive the same dispatch a real `WindowEvent` uses. Wheel deltas in
+/// `event` are DOM-signed; they are inverted into winit's incoming space
+/// so `winit_scroll_to_dom` is actually exercised.
+pub fn inject_test_input(
+  handlers: &EventHandlers,
+  ws: &WindowState,
+  window_id: u32,
+  event: &LaufeyTestInput,
+) -> bool {
+  let mods = laufey_to_modifiers_state(event.modifiers);
+  match event.kind {
+    LAUFEY_TEST_INPUT_KEY => {
+      let key = c_str_or_empty(event.key);
+      if is_modifier_key_name(&key) {
+        // Real KeyboardInput for these is skipped; use MODIFIERS.
+        return false;
+      }
+      let code = c_str_or_empty(event.code);
+      dispatch_raw_keyboard_event(
+        handlers,
+        window_id,
+        event.pressed,
+        &key,
+        &code,
+        mods,
+        event.repeat,
+      );
+      true
+    }
+    LAUFEY_TEST_INPUT_MOUSE_MOVE => {
+      let flush_enter = ws.note_cursor_move(event.x, event.y);
+      if flush_enter {
+        dispatch_cursor_enter_leave_event(handlers, ws, window_id, true, mods);
+      }
+      dispatch_mouse_move_event(handlers, window_id, event.x, event.y, mods);
+      true
+    }
+    LAUFEY_TEST_INPUT_MOUSE_BUTTON => {
+      let Some(button) = laufey_button_to_winit(event.button) else {
+        return false;
+      };
+      let state = if event.pressed {
+        winit::event::ElementState::Pressed
+      } else {
+        winit::event::ElementState::Released
+      };
+      dispatch_mouse_click_event(handlers, ws, window_id, state, button, mods);
+      true
+    }
+    LAUFEY_TEST_INPUT_WHEEL => {
+      let scale = {
+        let s = *ws.current_scale.lock().unwrap();
+        if s > 0.0 {
+          s
+        } else {
+          1.0
+        }
+      };
+      // Invert the DOM sign so the real mapping brings it back.
+      let delta = if event.delta_mode == LAUFEY_WHEEL_DELTA_PIXEL {
+        winit::event::MouseScrollDelta::PixelDelta(PhysicalPosition::new(
+          event.delta_x * scale,
+          -event.delta_y * scale,
+        ))
+      } else {
+        winit::event::MouseScrollDelta::LineDelta(
+          event.delta_x as f32,
+          -event.delta_y as f32,
+        )
+      };
+      dispatch_wheel_event(handlers, ws, window_id, delta, mods, scale);
+      true
+    }
+    LAUFEY_TEST_INPUT_CURSOR_ENTER => {
+      if ws.note_cursor_entered() {
+        dispatch_cursor_enter_leave_event(handlers, ws, window_id, true, mods);
+      }
+      true
+    }
+    LAUFEY_TEST_INPUT_CURSOR_LEAVE => {
+      ws.note_cursor_left();
+      dispatch_cursor_enter_leave_event(handlers, ws, window_id, false, mods);
+      true
+    }
+    LAUFEY_TEST_INPUT_MODIFIERS => {
+      let next = winit::event::Modifiers::from(mods);
+      let prev = {
+        let mut slot = ws.inject_modifiers.lock().unwrap();
+        std::mem::replace(&mut *slot, next)
+      };
+      for (pressed, key, code) in modifier_key_edges(&prev, &next) {
+        dispatch_raw_keyboard_event(
+          handlers,
+          window_id,
+          pressed,
+          key,
+          code,
+          next.state(),
+          false,
+        );
+      }
+      true
+    }
+    _ => false,
   }
 }
 
@@ -4379,6 +4972,14 @@ mod mouse_tests {
   }
 
   #[test]
+  fn laufey_mod_bits_round_trip_to_winit() {
+    let s = laufey_to_modifiers_state(LAUFEY_MOD_SHIFT | LAUFEY_MOD_META);
+    assert!(s.shift_key() && s.super_key());
+    assert!(!s.control_key() && !s.alt_key());
+    assert_eq!(modifiers_to_laufey(s), LAUFEY_MOD_SHIFT | LAUFEY_MOD_META);
+  }
+
+  #[test]
   fn enter_waits_for_the_first_move() {
     let ws = WindowState::new();
     assert!(!ws.note_cursor_entered());
@@ -4485,6 +5086,83 @@ mod mouse_tests {
     let ws = WindowState::new();
     assert_eq!(*ws.current_scale.lock().unwrap(), primary_scale_hint());
     assert!(*ws.current_scale.lock().unwrap() > 0.0);
+  }
+
+  #[test]
+  fn frameless_window_has_no_frame_offset() {
+    assert_eq!(frame_offset_hint(LAUFEY_WINDOW_FLAG_FRAMELESS), (0, 0));
+  }
+
+  #[cfg(any(target_os = "windows", target_os = "macos"))]
+  #[test]
+  fn decorated_window_offsets_by_the_title_bar() {
+    // A decorated window's content starts below the caption, so the hint has
+    // to be further down than the frame origin. Both the caption height and
+    // the border width vary by DPI and theme, so only the sign is asserted.
+    let (dx, dy) = frame_offset_hint(0);
+    assert!(dy > 0, "expected a caption offset, got {dy}");
+    assert!(dx >= 0, "expected a non-negative border offset, got {dx}");
+    assert!(dy > dx, "caption should exceed the side border");
+  }
+
+  #[test]
+  fn frameless_window_has_no_frame_extent() {
+    assert_eq!(frame_extent_hint(LAUFEY_WINDOW_FLAG_FRAMELESS), (0, 0));
+  }
+
+  #[cfg(any(target_os = "windows", target_os = "macos"))]
+  #[test]
+  fn decorated_window_extent_includes_the_title_bar() {
+    let (dw, dh) = frame_extent_hint(0);
+    assert!(dh > 0, "expected a caption height, got {dh}");
+    assert!(dw >= 0, "expected a non-negative border width, got {dw}");
+    assert!(dh > dw, "caption should exceed the side borders");
+  }
+
+  #[test]
+  fn new_window_starts_with_resize_reporting_disarmed() {
+    // Otherwise the creation-time `Resized` burst reaches the app.
+    let ws = WindowState::new();
+    assert!(!*ws.resize_reporting_armed.lock().unwrap());
+  }
+
+  #[test]
+  fn arming_resyncs_geometry_and_happens_once() {
+    let ws = WindowState::new();
+    assert!(arm_resize_reporting(
+      &ws,
+      Some((600, 400)),
+      1.5,
+      Some((7, 30))
+    ));
+    assert!(*ws.resize_reporting_armed.lock().unwrap());
+    assert_eq!(*ws.current_size.lock().unwrap(), Some((600, 400)));
+    assert_eq!(*ws.current_scale.lock().unwrap(), 1.5);
+    assert_eq!(*ws.current_inner_position.lock().unwrap(), Some((7, 30)));
+
+    // `about_to_wait` runs on every loop iteration, so this is called
+    // constantly; only the first call may touch the cache. Re-syncing later
+    // would clobber a real resize with a stale value.
+    assert!(!arm_resize_reporting(
+      &ws,
+      Some((999, 999)),
+      3.0,
+      Some((9, 9))
+    ));
+    assert_eq!(*ws.current_size.lock().unwrap(), Some((600, 400)));
+    assert_eq!(*ws.current_scale.lock().unwrap(), 1.5);
+    assert_eq!(*ws.current_inner_position.lock().unwrap(), Some((7, 30)));
+  }
+
+  #[test]
+  fn arming_without_geometry_still_arms() {
+    // A platform that cannot report size or position yet (Wayland gives no
+    // window position at all) must not leave reporting disarmed forever.
+    let ws = WindowState::new();
+    assert!(arm_resize_reporting(&ws, None, 1.0, None));
+    assert!(*ws.resize_reporting_armed.lock().unwrap());
+    assert_eq!(*ws.current_size.lock().unwrap(), None);
+    assert_eq!(*ws.current_inner_position.lock().unwrap(), None);
   }
 
   #[test]

--- a/backend-winit-common/src/lib.rs
+++ b/backend-winit-common/src/lib.rs
@@ -10,7 +10,7 @@ pub mod tray;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::env;
-use std::ffi::{c_char, c_int, c_void, CStr, CString};
+use std::ffi::{CStr, CString, c_char, c_int, c_void};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Condvar, Mutex};
@@ -1745,8 +1745,14 @@ pub struct WindowState {
   pub pending_app_menu: Mutex<Option<PendingMenu>>,
   pub pending_context_menu: Mutex<Option<PendingContextMenu>>,
   pub cursor_position: Mutex<(f64, f64)>,
+  /// False until the first `CursorMoved` (or a later move after `CursorLeft`).
+  /// `CursorEntered` often arrives before any move, so the last position is
+  /// still `(0, 0)` — we wait for a real coordinate before firing enter.
+  pub cursor_seen: Mutex<bool>,
+  pub pending_enter: Mutex<bool>,
   pub last_press_time: Mutex<Option<std::time::Instant>>,
   pub last_press_button: Mutex<Option<winit::event::MouseButton>>,
+  pub last_press_position: Mutex<Option<(f64, f64)>>,
   pub click_count: Mutex<i32>,
 }
 
@@ -1765,8 +1771,11 @@ impl WindowState {
       pending_app_menu: Mutex::new(None),
       pending_context_menu: Mutex::new(None),
       cursor_position: Mutex::new((0.0, 0.0)),
+      cursor_seen: Mutex::new(false),
+      pending_enter: Mutex::new(false),
       last_press_time: Mutex::new(None),
       last_press_button: Mutex::new(None),
+      last_press_position: Mutex::new(None),
       click_count: Mutex::new(0),
     }
   }
@@ -1775,6 +1784,32 @@ impl WindowState {
 impl Default for WindowState {
   fn default() -> Self {
     Self::new()
+  }
+}
+
+impl WindowState {
+  /// Store a cursor position. Returns true if a deferred `mouseenter` should
+  /// fire before the matching `mousemove`.
+  pub fn note_cursor_move(&self, x: f64, y: f64) -> bool {
+    *self.cursor_position.lock().unwrap() = (x, y);
+    *self.cursor_seen.lock().unwrap() = true;
+    std::mem::replace(&mut *self.pending_enter.lock().unwrap(), false)
+  }
+
+  /// Returns true if enter can be dispatched now. Otherwise the next move
+  /// flushes it once a real coordinate exists.
+  pub fn note_cursor_entered(&self) -> bool {
+    if *self.cursor_seen.lock().unwrap() {
+      true
+    } else {
+      *self.pending_enter.lock().unwrap() = true;
+      false
+    }
+  }
+
+  pub fn note_cursor_left(&self) {
+    *self.pending_enter.lock().unwrap() = false;
+    *self.cursor_seen.lock().unwrap() = false;
   }
 }
 
@@ -2467,11 +2502,7 @@ macro_rules! define_common_backend_fns {
           }
         }
       }
-      if confirmed {
-        1
-      } else {
-        0
-      }
+      if confirmed { 1 } else { 0 }
     }
 
     unsafe extern "C" fn backend_string_free(
@@ -3569,9 +3600,39 @@ pub fn winit_button_to_laufey(button: winit::event::MouseButton) -> c_int {
 }
 
 /// Dispatch a mouse click event to the registered handler.
-/// Double-click interval (500ms is the standard across most platforms).
+/// Same rule as CEF's Linux tracker: increment while the same button lands
+/// nearby within 500ms. The previous `count < 2` / reset-to-1 split ignored
+/// pointer travel and collapsed a triple-click back to 1.
 const DOUBLE_CLICK_INTERVAL: std::time::Duration =
   std::time::Duration::from_millis(500);
+const MULTI_CLICK_DISTANCE: f64 = 4.0;
+
+pub fn next_click_count(
+  prev_button: Option<winit::event::MouseButton>,
+  prev_pos: Option<(f64, f64)>,
+  prev_time: Option<std::time::Instant>,
+  prev_count: i32,
+  button: winit::event::MouseButton,
+  x: f64,
+  y: f64,
+  now: std::time::Instant,
+) -> i32 {
+  let close = prev_pos
+    .map(|(px, py)| {
+      let dx = x - px;
+      let dy = y - py;
+      dx * dx + dy * dy <= MULTI_CLICK_DISTANCE * MULTI_CLICK_DISTANCE
+    })
+    .unwrap_or(false);
+  if prev_button == Some(button)
+    && prev_time.is_some_and(|t| now.duration_since(t) < DOUBLE_CLICK_INTERVAL)
+    && close
+  {
+    prev_count + 1
+  } else {
+    1
+  }
+}
 
 pub fn dispatch_mouse_click_event(
   handlers: &EventHandlers,
@@ -3598,19 +3659,14 @@ pub fn dispatch_mouse_click_event(
       let now = std::time::Instant::now();
       let mut last_time = ws.last_press_time.lock().unwrap();
       let mut last_btn = ws.last_press_button.lock().unwrap();
+      let mut last_pos = ws.last_press_position.lock().unwrap();
       let mut count = ws.click_count.lock().unwrap();
-
-      if *last_btn == Some(button)
-        && *count < 2
-        && last_time
-          .is_some_and(|t| now.duration_since(t) < DOUBLE_CLICK_INTERVAL)
-      {
-        *count = 2;
-      } else if *count >= 2 || *last_btn != Some(button) {
-        *count = 1;
-      }
+      *count = next_click_count(
+        *last_btn, *last_pos, *last_time, *count, button, x, y, now,
+      );
       *last_time = Some(now);
       *last_btn = Some(button);
+      *last_pos = Some((x, y));
       *count
     } else {
       *ws.click_count.lock().unwrap()
@@ -3647,6 +3703,24 @@ pub fn dispatch_mouse_move_event(
   }
 }
 
+/// Map a winit scroll delta to DOM `WheelEvent` units.
+///
+/// winit / Cocoa report positive Y for scroll *up*. The Web `WheelEvent`
+/// contract (and GTK's webview backend here) uses positive Y for scroll
+/// *down*. Flip Y only; X already matches (positive = right).
+pub fn winit_scroll_to_dom(
+  delta: winit::event::MouseScrollDelta,
+) -> (f64, f64, i32) {
+  match delta {
+    winit::event::MouseScrollDelta::LineDelta(dx, dy) => {
+      (dx as f64, -(dy as f64), LAUFEY_WHEEL_DELTA_LINE)
+    }
+    winit::event::MouseScrollDelta::PixelDelta(d) => {
+      (d.x, -d.y, LAUFEY_WHEEL_DELTA_PIXEL)
+    }
+  }
+}
+
 pub fn dispatch_wheel_event(
   handlers: &EventHandlers,
   ws: &WindowState,
@@ -3656,14 +3730,7 @@ pub fn dispatch_wheel_event(
 ) {
   let handler = handlers.wheel_handler.lock().unwrap();
   if let Some((cb, user_data)) = *handler {
-    let (delta_x, delta_y, delta_mode) = match delta {
-      winit::event::MouseScrollDelta::LineDelta(dx, dy) => {
-        (dx as f64, dy as f64, LAUFEY_WHEEL_DELTA_LINE)
-      }
-      winit::event::MouseScrollDelta::PixelDelta(d) => {
-        (d.x, d.y, LAUFEY_WHEEL_DELTA_PIXEL)
-      }
-    };
+    let (delta_x, delta_y, delta_mode) = winit_scroll_to_dom(delta);
     let (x, y) = *ws.cursor_position.lock().unwrap();
     let mods = modifiers_to_laufey(modifiers);
     unsafe {
@@ -3893,8 +3960,173 @@ pub fn load_and_start_runtime(api: LaufeyBackendApi) {
       });
     }
     None => {
-      println!("No runtime library found. Set LAUFEY_RUNTIME_PATH or place libruntime in current directory.");
+      println!(
+        "No runtime library found. Set LAUFEY_RUNTIME_PATH or place libruntime in current directory."
+      );
       println!("Starting without runtime integration...");
     }
+  }
+}
+
+#[cfg(test)]
+mod mouse_tests {
+  use super::*;
+  use std::time::{Duration, Instant};
+  use winit::event::MouseButton;
+
+  fn count(
+    prev_button: Option<MouseButton>,
+    prev_pos: Option<(f64, f64)>,
+    prev_count: i32,
+    button: MouseButton,
+    x: f64,
+    y: f64,
+    dt_ms: u64,
+  ) -> i32 {
+    let now = Instant::now();
+    let prev_time = if dt_ms == u64::MAX {
+      None
+    } else {
+      now.checked_sub(Duration::from_millis(dt_ms))
+    };
+    next_click_count(
+      prev_button,
+      prev_pos,
+      prev_time,
+      prev_count,
+      button,
+      x,
+      y,
+      now,
+    )
+  }
+
+  #[test]
+  fn first_press_is_click_count_1() {
+    assert_eq!(
+      count(None, None, 0, MouseButton::Left, 10.0, 10.0, u64::MAX),
+      1
+    );
+  }
+
+  #[test]
+  fn second_press_nearby_is_2() {
+    assert_eq!(
+      count(
+        Some(MouseButton::Left),
+        Some((10.0, 10.0)),
+        1,
+        MouseButton::Left,
+        11.0,
+        10.0,
+        100,
+      ),
+      2
+    );
+  }
+
+  #[test]
+  fn third_press_nearby_is_3() {
+    assert_eq!(
+      count(
+        Some(MouseButton::Left),
+        Some((10.0, 10.0)),
+        2,
+        MouseButton::Left,
+        10.0,
+        12.0,
+        100,
+      ),
+      3
+    );
+  }
+
+  #[test]
+  fn far_press_restarts_at_1() {
+    assert_eq!(
+      count(
+        Some(MouseButton::Left),
+        Some((10.0, 10.0)),
+        1,
+        MouseButton::Left,
+        40.0,
+        10.0,
+        100,
+      ),
+      1
+    );
+  }
+
+  #[test]
+  fn late_press_restarts_at_1() {
+    assert_eq!(
+      count(
+        Some(MouseButton::Left),
+        Some((10.0, 10.0)),
+        1,
+        MouseButton::Left,
+        10.0,
+        10.0,
+        600,
+      ),
+      1
+    );
+  }
+
+  #[test]
+  fn other_button_restarts_at_1() {
+    assert_eq!(
+      count(
+        Some(MouseButton::Left),
+        Some((10.0, 10.0)),
+        1,
+        MouseButton::Right,
+        10.0,
+        10.0,
+        100,
+      ),
+      1
+    );
+  }
+
+  #[test]
+  fn enter_waits_for_the_first_move() {
+    let ws = WindowState::new();
+    assert!(!ws.note_cursor_entered());
+    assert!(ws.note_cursor_move(40.0, 50.0));
+    assert_eq!(*ws.cursor_position.lock().unwrap(), (40.0, 50.0));
+    assert!(!ws.note_cursor_move(41.0, 50.0));
+  }
+
+  #[test]
+  fn leave_forgets_the_last_inside_point() {
+    let ws = WindowState::new();
+    assert!(!ws.note_cursor_move(40.0, 50.0));
+    ws.note_cursor_left();
+    assert!(!ws.note_cursor_entered());
+    assert!(ws.note_cursor_move(80.0, 20.0));
+  }
+
+  #[test]
+  fn line_scroll_maps_winit_up_to_dom_negative() {
+    // winit LineDelta +Y is scroll up; DOM wants +Y for scroll down.
+    let (dx, dy, mode) =
+      winit_scroll_to_dom(winit::event::MouseScrollDelta::LineDelta(0.0, 3.0));
+    assert_eq!(dx, 0.0);
+    assert_eq!(dy, -3.0);
+    assert_eq!(mode, LAUFEY_WHEEL_DELTA_LINE);
+    let (_, down, _) =
+      winit_scroll_to_dom(winit::event::MouseScrollDelta::LineDelta(0.0, -3.0));
+    assert_eq!(down, 3.0);
+  }
+
+  #[test]
+  fn pixel_scroll_flips_y_only() {
+    let (dx, dy, mode) =
+      winit_scroll_to_dom(winit::event::MouseScrollDelta::PixelDelta(
+        winit::dpi::PhysicalPosition { x: 4.0, y: 8.0 },
+      ));
+    assert_eq!((dx, dy), (4.0, -8.0));
+    assert_eq!(mode, LAUFEY_WHEEL_DELTA_PIXEL);
   }
 }

--- a/backend-winit-common/src/lib.rs
+++ b/backend-winit-common/src/lib.rs
@@ -10,7 +10,7 @@ pub mod tray;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::env;
-use std::ffi::{CStr, CString, c_char, c_int, c_void};
+use std::ffi::{c_char, c_int, c_void, CStr, CString};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Condvar, Mutex};
@@ -23,7 +23,9 @@ use muda::MenuEvent;
 use raw_window_handle::{
   HasDisplayHandle, HasWindowHandle, RawDisplayHandle, RawWindowHandle,
 };
-use winit::dpi::{LogicalPosition, LogicalSize};
+use winit::dpi::{
+  LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize,
+};
 use winit::event_loop::EventLoopProxy;
 use winit::window::{Window, WindowLevel};
 
@@ -33,7 +35,7 @@ use winit::window::{Window, WindowLevel};
 // Bumping this in lockstep with the capi is mandatory: the capi's `init_api`
 // rejects any backend whose reported `version` differs, and the vtable layout
 // below must match the `laufey_backend_api` struct as of this version.
-pub const LAUFEY_API_VERSION: u32 = 34;
+pub const LAUFEY_API_VERSION: u32 = 35;
 
 /// Creation-time window style flags (mirror `LAUFEY_WINDOW_FLAG_*` in laufey.h).
 pub const LAUFEY_WINDOW_FLAG_FRAMELESS: u32 = 1 << 0;
@@ -564,6 +566,14 @@ pub struct LaufeyBackendApi {
     Option<unsafe extern "C" fn(*mut c_void, u32, bool)>,
   pub is_click_passthrough_forward:
     Option<unsafe extern "C" fn(*mut c_void, u32) -> bool>,
+
+  // --- Device pixel ratio (API >= 35) ---
+  pub get_window_scale_factor:
+    Option<unsafe extern "C" fn(*mut c_void, u32) -> f64>,
+
+  // --- Content-view origin (API >= 35) ---
+  pub get_window_inner_position:
+    Option<unsafe extern "C" fn(*mut c_void, u32, *mut c_int, *mut c_int)>,
 }
 
 unsafe impl Send for LaufeyBackendApi {}
@@ -1206,6 +1216,10 @@ pub fn create_api_base() -> LaufeyBackendApi {
     // observation API.
     set_click_passthrough_forward: None,
     is_click_passthrough_forward: None,
+    // Device pixel ratio (API >= 35): filled by fill_common_api.
+    get_window_scale_factor: None,
+    // Content-view origin (API >= 35): filled by fill_common_api.
+    get_window_inner_position: None,
   }
 }
 
@@ -1728,12 +1742,19 @@ pub fn dispatch_menu_click_by_id(item_id: &str) -> bool {
 pub struct WindowState {
   pub pending_title: Mutex<Option<String>>,
   pub pending_size: Mutex<Option<(i32, i32)>>,
-  /// Authoritative current window size in physical pixels. Unlike
+  /// Authoritative current window size in logical (DIP) pixels. Unlike
   /// `pending_size` (a one-shot *requested* size that's consumed when applied),
   /// this tracks the window's real dimensions: seeded at creation from
-  /// `inner_size()` and refreshed on every resize. Backs `get_window_size` so
-  /// it never reports 0x0 (which produced a 0x0 wgpu surface).
+  /// `inner_size()` converted by `scale_factor`, and refreshed on every resize.
+  /// Backs `get_window_size` so it never reports 0x0 (which produced a 0x0 wgpu
+  /// surface) and matches CEF / WebView / `set_size`.
   pub current_size: Mutex<Option<(i32, i32)>>,
+  /// `window.scale_factor()`, seeded at create and refreshed on
+  /// `ScaleFactorChanged`. Backs `get_window_scale_factor`.
+  pub current_scale: Mutex<f64>,
+  /// Content-view top-left in screen DIP. `getPosition` is the frame;
+  /// this plus `clientX`/`clientY` is `MouseEvent.screenX`/`screenY`.
+  pub current_inner_position: Mutex<Option<(i32, i32)>>,
   pub pending_position: Mutex<Option<(i32, i32)>>,
   pub pending_resizable: Mutex<Option<bool>>,
   pub pending_always_on_top: Mutex<Option<bool>>,
@@ -1762,6 +1783,8 @@ impl WindowState {
       pending_title: Mutex::new(None),
       pending_size: Mutex::new(None),
       current_size: Mutex::new(None),
+      current_scale: Mutex::new(primary_scale_hint()),
+      current_inner_position: Mutex::new(None),
       pending_position: Mutex::new(None),
       pending_resizable: Mutex::new(None),
       pending_always_on_top: Mutex::new(None),
@@ -2097,6 +2120,50 @@ macro_rules! define_common_backend_fns {
         if !height.is_null() {
           *height = 0;
         }
+      }
+    }
+
+    unsafe extern "C" fn backend_get_window_scale_factor(
+      _data: *mut ::std::ffi::c_void,
+      window_id: u32,
+    ) -> f64 {
+      if let Some(state) = <$B as $crate::BackendAccess>::get() {
+        if let Some(scale) = state
+          .common()
+          .with_window(window_id, |ws| *ws.current_scale.lock().unwrap())
+        {
+          if scale > 0.0 {
+            return scale;
+          }
+        }
+      }
+      1.0
+    }
+
+    unsafe extern "C" fn backend_get_window_inner_position(
+      _data: *mut ::std::ffi::c_void,
+      window_id: u32,
+      x: *mut ::std::ffi::c_int,
+      y: *mut ::std::ffi::c_int,
+    ) {
+      let mut px = 0;
+      let mut py = 0;
+      if let Some(state) = <$B as $crate::BackendAccess>::get() {
+        let _ = state.common().with_window(window_id, |ws| {
+          if let Some((ix, iy)) = *ws.current_inner_position.lock().unwrap() {
+            px = ix;
+            py = iy;
+          } else if let Some((ox, oy)) = *ws.pending_position.lock().unwrap() {
+            px = ox;
+            py = oy;
+          }
+        });
+      }
+      if !x.is_null() {
+        *x = px;
+      }
+      if !y.is_null() {
+        *y = py;
       }
     }
 
@@ -2502,7 +2569,11 @@ macro_rules! define_common_backend_fns {
           }
         }
       }
-      if confirmed { 1 } else { 0 }
+      if confirmed {
+        1
+      } else {
+        0
+      }
     }
 
     unsafe extern "C" fn backend_string_free(
@@ -2936,6 +3007,8 @@ macro_rules! fill_common_api {
     $api.quit = Some(backend_quit);
     $api.set_window_size = Some(backend_set_window_size);
     $api.get_window_size = Some(backend_get_window_size);
+    $api.get_window_scale_factor = Some(backend_get_window_scale_factor);
+    $api.get_window_inner_position = Some(backend_get_window_inner_position);
     $api.set_window_position = Some(backend_set_window_position);
     $api.get_window_position = Some(backend_get_window_position);
     $api.set_resizable = Some(backend_set_resizable);
@@ -3194,6 +3267,82 @@ pub fn handle_common_event<B: BackendAccess>(
   }
 }
 
+/// Physical → DIP integers. CEF / WebView report points; `set_size` already
+/// takes `LogicalSize`.
+pub fn physical_size_to_logical_i32(
+  width: u32,
+  height: u32,
+  scale_factor: f64,
+) -> (i32, i32) {
+  let scale = if scale_factor > 0.0 {
+    scale_factor
+  } else {
+    1.0
+  };
+  let size = PhysicalSize::new(width, height).to_logical::<f64>(scale);
+  (size.width.round() as i32, size.height.round() as i32)
+}
+
+pub fn physical_pos_to_logical_i32(
+  x: i32,
+  y: i32,
+  scale_factor: f64,
+) -> (i32, i32) {
+  let scale = if scale_factor > 0.0 {
+    scale_factor
+  } else {
+    1.0
+  };
+  let pos = PhysicalPosition::new(x, y).to_logical::<f64>(scale);
+  (pos.x.round() as i32, pos.y.round() as i32)
+}
+
+/// Best-effort scale before the winit `Window` exists. JS may read
+/// `devicePixelRatio` from the constructor, which runs before `CreateWindow`
+/// is processed.
+pub fn primary_scale_hint() -> f64 {
+  #[cfg(target_os = "macos")]
+  {
+    use objc2::msg_send;
+    use objc2::runtime::{AnyClass, AnyObject};
+    let Some(cls) = AnyClass::get(c"NSScreen") else {
+      return 1.0;
+    };
+    let screen: Option<&AnyObject> = unsafe { msg_send![cls, mainScreen] };
+    let Some(screen) = screen else {
+      return 1.0;
+    };
+    let scale: f64 = unsafe { msg_send![screen, backingScaleFactor] };
+    return if scale > 0.0 { scale } else { 1.0 };
+  }
+  #[cfg(target_os = "windows")]
+  {
+    windows_sys::Win32::UI::HiDpi::GetDpiForSystem() as f64 / 96.0
+  }
+  #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+  {
+    std::env::var("GDK_SCALE")
+      .ok()
+      .and_then(|s| s.parse().ok())
+      .filter(|s: &f64| *s > 0.0)
+      .unwrap_or(1.0)
+  }
+}
+
+pub fn physical_pos_to_logical_f64(
+  x: f64,
+  y: f64,
+  scale_factor: f64,
+) -> (f64, f64) {
+  let scale = if scale_factor > 0.0 {
+    scale_factor
+  } else {
+    1.0
+  };
+  let pos = PhysicalPosition::new(x, y).to_logical::<f64>(scale);
+  (pos.x, pos.y)
+}
+
 /// Apply pending state to window attributes before creation.
 pub fn apply_pending_attrs(
   ws: &WindowState,
@@ -3238,10 +3387,16 @@ pub fn apply_pending_post_create(ws: &WindowState, window: &Window) {
   // to arrive — reliable on X11, racy on Wayland — which left
   // `getNativeWindow()` handing wgpu a 0x0 surface ("surface is not configured
   // for presentation").
+  let scale = window.scale_factor();
   let size = window.inner_size();
   if size.width > 0 && size.height > 0 {
-    *ws.current_size.lock().unwrap() =
-      Some((size.width as i32, size.height as i32));
+    let (w, h) = physical_size_to_logical_i32(size.width, size.height, scale);
+    *ws.current_size.lock().unwrap() = Some((w, h));
+    *ws.current_scale.lock().unwrap() = scale;
+  }
+  if let Ok(inner) = window.inner_position() {
+    *ws.current_inner_position.lock().unwrap() =
+      Some(physical_pos_to_logical_i32(inner.x, inner.y, scale));
   }
 
   if let Some(true) = *ws.pending_always_on_top.lock().unwrap() {
@@ -3710,13 +3865,15 @@ pub fn dispatch_mouse_move_event(
 /// *down*. Flip Y only; X already matches (positive = right).
 pub fn winit_scroll_to_dom(
   delta: winit::event::MouseScrollDelta,
+  scale_factor: f64,
 ) -> (f64, f64, i32) {
   match delta {
     winit::event::MouseScrollDelta::LineDelta(dx, dy) => {
       (dx as f64, -(dy as f64), LAUFEY_WHEEL_DELTA_LINE)
     }
     winit::event::MouseScrollDelta::PixelDelta(d) => {
-      (d.x, -d.y, LAUFEY_WHEEL_DELTA_PIXEL)
+      let (dx, dy) = physical_pos_to_logical_f64(d.x, d.y, scale_factor);
+      (dx, -dy, LAUFEY_WHEEL_DELTA_PIXEL)
     }
   }
 }
@@ -3727,10 +3884,12 @@ pub fn dispatch_wheel_event(
   window_id: u32,
   delta: winit::event::MouseScrollDelta,
   modifiers: winit::keyboard::ModifiersState,
+  scale_factor: f64,
 ) {
   let handler = handlers.wheel_handler.lock().unwrap();
   if let Some((cb, user_data)) = *handler {
-    let (delta_x, delta_y, delta_mode) = winit_scroll_to_dom(delta);
+    let (delta_x, delta_y, delta_mode) =
+      winit_scroll_to_dom(delta, scale_factor);
     let (x, y) = *ws.cursor_position.lock().unwrap();
     let mods = modifiers_to_laufey(modifiers);
     unsafe {
@@ -4110,23 +4269,61 @@ mod mouse_tests {
   #[test]
   fn line_scroll_maps_winit_up_to_dom_negative() {
     // winit LineDelta +Y is scroll up; DOM wants +Y for scroll down.
-    let (dx, dy, mode) =
-      winit_scroll_to_dom(winit::event::MouseScrollDelta::LineDelta(0.0, 3.0));
+    let (dx, dy, mode) = winit_scroll_to_dom(
+      winit::event::MouseScrollDelta::LineDelta(0.0, 3.0),
+      2.0,
+    );
     assert_eq!(dx, 0.0);
     assert_eq!(dy, -3.0);
     assert_eq!(mode, LAUFEY_WHEEL_DELTA_LINE);
-    let (_, down, _) =
-      winit_scroll_to_dom(winit::event::MouseScrollDelta::LineDelta(0.0, -3.0));
+    let (_, down, _) = winit_scroll_to_dom(
+      winit::event::MouseScrollDelta::LineDelta(0.0, -3.0),
+      2.0,
+    );
     assert_eq!(down, 3.0);
   }
 
   #[test]
   fn pixel_scroll_flips_y_only() {
-    let (dx, dy, mode) =
-      winit_scroll_to_dom(winit::event::MouseScrollDelta::PixelDelta(
+    let (dx, dy, mode) = winit_scroll_to_dom(
+      winit::event::MouseScrollDelta::PixelDelta(
         winit::dpi::PhysicalPosition { x: 4.0, y: 8.0 },
-      ));
+      ),
+      1.0,
+    );
     assert_eq!((dx, dy), (4.0, -8.0));
     assert_eq!(mode, LAUFEY_WHEEL_DELTA_PIXEL);
+  }
+
+  #[test]
+  fn pixel_scroll_divides_by_scale() {
+    let (dx, dy, mode) = winit_scroll_to_dom(
+      winit::event::MouseScrollDelta::PixelDelta(
+        winit::dpi::PhysicalPosition { x: 8.0, y: 16.0 },
+      ),
+      2.0,
+    );
+    assert_eq!((dx, dy), (4.0, -8.0));
+    assert_eq!(mode, LAUFEY_WHEEL_DELTA_PIXEL);
+  }
+
+  #[test]
+  fn physical_size_at_2x_is_constructor_logical() {
+    assert_eq!(physical_size_to_logical_i32(960, 640, 2.0), (480, 320));
+    assert_eq!(physical_size_to_logical_i32(960, 720, 1.5), (640, 480));
+    assert_eq!(physical_size_to_logical_i32(480, 320, 1.0), (480, 320));
+  }
+
+  #[test]
+  fn new_window_scale_uses_primary_hint() {
+    let ws = WindowState::new();
+    assert_eq!(*ws.current_scale.lock().unwrap(), primary_scale_hint());
+    assert!(*ws.current_scale.lock().unwrap() > 0.0);
+  }
+
+  #[test]
+  fn physical_cursor_at_2x_is_logical() {
+    assert_eq!(physical_pos_to_logical_f64(40.0, 40.0, 2.0), (20.0, 20.0));
+    assert_eq!(physical_pos_to_logical_i32(100, 200, 2.0), (50, 100));
   }
 }

--- a/capi/include/laufey.h
+++ b/capi/include/laufey.h
@@ -206,8 +206,8 @@ typedef void (*laufey_mouse_move_fn)(
 // Callback for wheel (scroll) events.
 typedef void (*laufey_wheel_fn)(
     void* user_data, uint32_t window_id,
-    double delta_x,      // horizontal scroll amount
-    double delta_y,      // vertical scroll amount
+    double delta_x,      // horizontal scroll; positive = right (DOM WheelEvent)
+    double delta_y,      // vertical scroll; positive = down (DOM WheelEvent)
     double x,            // cursor x position in window coordinates
     double y,            // cursor y position in window coordinates
     uint32_t modifiers,  // bitmask of LAUFEY_MOD_* flags

--- a/capi/include/laufey.h
+++ b/capi/include/laufey.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-#define LAUFEY_API_VERSION 34
+#define LAUFEY_API_VERSION 35
 
 // Window handle types for get_window_handle_type
 #define LAUFEY_WINDOW_HANDLE_UNKNOWN 0
@@ -841,6 +841,25 @@ struct laufey_backend_api {
   // false if the id is unknown or the backend doesn't support forwarding.
   // NULL on backends older than API version 34.
   bool (*is_click_passthrough_forward)(void* backend_data, uint32_t window_id);
+
+  // --- Device pixel ratio (API >= 35) ----------------------------------------
+  //
+  // Physical pixels per density-independent pixel for this window, the same
+  // ratio as the Web `window.devicePixelRatio`. Live: a window that moves to
+  // another monitor reports the new scale on the next call. Returns 1.0 if
+  // the id is unknown. NULL on backends older than API version 35; callers
+  // must null-check and treat NULL as 1.0.
+  double (*get_window_scale_factor)(void* backend_data, uint32_t window_id);
+
+  // --- Content-view origin (API >= 35) ---------------------------------------
+  //
+  // Top-left of the content view in the same DIP, top-left-origin screen
+  // space as get_window_position. Differs from get_window_position by the
+  // title-bar / frame chrome, so `inner + clientX/Y` is MouseEvent.screenX/Y.
+  // Writes 0,0 if the id is unknown. NULL on backends older than API 35;
+  // callers must null-check and fall back to get_window_position.
+  void (*get_window_inner_position)(void* backend_data, uint32_t window_id,
+                                    int* x, int* y);
 };
 
 #ifdef __cplusplus

--- a/capi/include/laufey.h
+++ b/capi/include/laufey.h
@@ -116,6 +116,33 @@ typedef void (*laufey_menu_click_fn)(void* user_data, uint32_t window_id,
 #define LAUFEY_MOUSE_PRESSED 0
 #define LAUFEY_MOUSE_RELEASED 1
 
+// Synthetic input kinds for test_inject_input (API >= 35).
+#define LAUFEY_TEST_INPUT_KEY 0
+#define LAUFEY_TEST_INPUT_MOUSE_MOVE 1
+#define LAUFEY_TEST_INPUT_MOUSE_BUTTON 2
+#define LAUFEY_TEST_INPUT_WHEEL 3
+#define LAUFEY_TEST_INPUT_CURSOR_ENTER 4
+#define LAUFEY_TEST_INPUT_CURSOR_LEAVE 5
+#define LAUFEY_TEST_INPUT_MODIFIERS 6
+
+// Test-only input record. Unused fields are ignored per `kind`. Wheel
+// deltas are DOM-signed (positive Y is scroll down); the winit backend
+// converts them through the same mapping a real OS event uses.
+typedef struct laufey_test_input {
+  int kind;            // LAUFEY_TEST_INPUT_*
+  uint32_t modifiers;  // bitmask of LAUFEY_MOD_*
+  const char* key;     // KEY
+  const char* code;    // KEY
+  bool pressed;        // KEY / MOUSE_BUTTON
+  bool repeat;         // KEY
+  int button;          // MOUSE_BUTTON: LAUFEY_MOUSE_BUTTON_*
+  double x;            // MOVE / BUTTON / WHEEL / ENTER / LEAVE
+  double y;
+  double delta_x;  // WHEEL
+  double delta_y;
+  int delta_mode;  // WHEEL: LAUFEY_WHEEL_DELTA_*
+} laufey_test_input_t;
+
 // Dialog types
 #define LAUFEY_DIALOG_ALERT 0
 #define LAUFEY_DIALOG_CONFIRM 1
@@ -860,6 +887,27 @@ struct laufey_backend_api {
   // callers must null-check and fall back to get_window_position.
   void (*get_window_inner_position)(void* backend_data, uint32_t window_id,
                                     int* x, int* y);
+
+  // --- Outer window size (API >= 35) -----------------------------------------
+  //
+  // Chrome-inclusive size in the same DIP space as get_window_size
+  // (`window.outerWidth` / `outerHeight`). A frameless window matches
+  // get_window_size. Writes 0,0 if the id is unknown. NULL on backends
+  // older than this field; callers must null-check and fall back to
+  // get_window_size.
+  void (*get_window_outer_size)(void* backend_data, uint32_t window_id,
+                                int* width, int* height);
+
+  // --- Test input injection (API >= 35) --------------------------------------
+  //
+  // Test-only. Posts a synthetic input event through the same dispatch a
+  // real OS event uses for this backend (winit: WindowEvent handlers;
+  // CEF / WebView: Dispatch* after native translation). Returns true if
+  // the event was accepted (known kind; winit also requires a live
+  // window). NULL on backends that do not implement it; callers should
+  // treat NULL like the other test hooks.
+  bool (*test_inject_input)(void* backend_data, uint32_t window_id,
+                            const laufey_test_input_t* event);
 };
 
 #ifdef __cplusplus

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -830,6 +830,20 @@ impl Window {
     (width, height)
   }
 
+  /// Chrome-inclusive size (`window.outerWidth` / `outerHeight`).
+  /// Falls back to [`Window::get_size`] when the backend does not report it.
+  pub fn get_outer_size(&self) -> (i32, i32) {
+    let api = api();
+    if let Some(f) = api.get_window_outer_size {
+      let mut width: c_int = 0;
+      let mut height: c_int = 0;
+      unsafe { f(api.backend_data, self.id, &mut width, &mut height) };
+      (width, height)
+    } else {
+      self.get_size()
+    }
+  }
+
   /// Physical pixels per DIP for this window (`window.devicePixelRatio`).
   /// Returns `1.0` when the backend does not report a scale.
   pub fn get_scale_factor(&self) -> f64 {
@@ -1675,6 +1689,162 @@ pub fn test_trigger_close_requested(window_id: u32) -> bool {
     return false;
   };
   unsafe { f(api.backend_data, window_id) }
+}
+
+pub const LAUFEY_TEST_INPUT_KEY: i32 = 0;
+pub const LAUFEY_TEST_INPUT_MOUSE_MOVE: i32 = 1;
+pub const LAUFEY_TEST_INPUT_MOUSE_BUTTON: i32 = 2;
+pub const LAUFEY_TEST_INPUT_WHEEL: i32 = 3;
+pub const LAUFEY_TEST_INPUT_CURSOR_ENTER: i32 = 4;
+pub const LAUFEY_TEST_INPUT_CURSOR_LEAVE: i32 = 5;
+pub const LAUFEY_TEST_INPUT_MODIFIERS: i32 = 6;
+
+/// A synthetic input event for [`test_inject_input`].
+#[derive(Clone, Debug)]
+pub enum TestInput {
+  Key {
+    key: String,
+    code: String,
+    pressed: bool,
+    repeat: bool,
+    modifiers: u32,
+  },
+  MouseMove {
+    x: f64,
+    y: f64,
+    modifiers: u32,
+  },
+  MouseButton {
+    button: i32,
+    pressed: bool,
+    x: f64,
+    y: f64,
+    modifiers: u32,
+  },
+  Wheel {
+    delta_x: f64,
+    delta_y: f64,
+    delta_mode: i32,
+    x: f64,
+    y: f64,
+    modifiers: u32,
+  },
+  CursorEnter {
+    x: f64,
+    y: f64,
+    modifiers: u32,
+  },
+  CursorLeave {
+    x: f64,
+    y: f64,
+    modifiers: u32,
+  },
+  Modifiers {
+    modifiers: u32,
+  },
+}
+
+/// Test-only. Posts `event` through the same dispatch a real OS event uses.
+/// Returns `false` if the backend has no hook, the window is unknown (winit),
+/// or the event was rejected (unknown kind / modifier sent as `Key`).
+///
+/// Wheel deltas are DOM-signed (positive Y is scroll down).
+pub fn test_inject_input(window_id: u32, event: &TestInput) -> bool {
+  let api = api();
+  let Some(f) = api.test_inject_input else {
+    return false;
+  };
+  let mut key = None;
+  let mut code = None;
+  let mut raw = ffi::laufey_test_input {
+    kind: 0,
+    modifiers: 0,
+    key: std::ptr::null(),
+    code: std::ptr::null(),
+    pressed: false,
+    repeat: false,
+    button: 0,
+    x: 0.0,
+    y: 0.0,
+    delta_x: 0.0,
+    delta_y: 0.0,
+    delta_mode: 0,
+  };
+  match event {
+    TestInput::Key {
+      key: k,
+      code: c,
+      pressed,
+      repeat,
+      modifiers,
+    } => {
+      raw.kind = LAUFEY_TEST_INPUT_KEY;
+      raw.modifiers = *modifiers;
+      raw.pressed = *pressed;
+      raw.repeat = *repeat;
+      key = CString::new(k.as_str()).ok();
+      code = CString::new(c.as_str()).ok();
+      raw.key = key.as_ref().map(|s| s.as_ptr()).unwrap_or(std::ptr::null());
+      raw.code = code
+        .as_ref()
+        .map(|s| s.as_ptr())
+        .unwrap_or(std::ptr::null());
+    }
+    TestInput::MouseMove { x, y, modifiers } => {
+      raw.kind = LAUFEY_TEST_INPUT_MOUSE_MOVE;
+      raw.modifiers = *modifiers;
+      raw.x = *x;
+      raw.y = *y;
+    }
+    TestInput::MouseButton {
+      button,
+      pressed,
+      x,
+      y,
+      modifiers,
+    } => {
+      raw.kind = LAUFEY_TEST_INPUT_MOUSE_BUTTON;
+      raw.modifiers = *modifiers;
+      raw.pressed = *pressed;
+      raw.button = *button;
+      raw.x = *x;
+      raw.y = *y;
+    }
+    TestInput::Wheel {
+      delta_x,
+      delta_y,
+      delta_mode,
+      x,
+      y,
+      modifiers,
+    } => {
+      raw.kind = LAUFEY_TEST_INPUT_WHEEL;
+      raw.modifiers = *modifiers;
+      raw.delta_x = *delta_x;
+      raw.delta_y = *delta_y;
+      raw.delta_mode = *delta_mode;
+      raw.x = *x;
+      raw.y = *y;
+    }
+    TestInput::CursorEnter { x, y, modifiers } => {
+      raw.kind = LAUFEY_TEST_INPUT_CURSOR_ENTER;
+      raw.modifiers = *modifiers;
+      raw.x = *x;
+      raw.y = *y;
+    }
+    TestInput::CursorLeave { x, y, modifiers } => {
+      raw.kind = LAUFEY_TEST_INPUT_CURSOR_LEAVE;
+      raw.modifiers = *modifiers;
+      raw.x = *x;
+      raw.y = *y;
+    }
+    TestInput::Modifiers { modifiers } => {
+      raw.kind = LAUFEY_TEST_INPUT_MODIFIERS;
+      raw.modifiers = *modifiers;
+    }
+  }
+  let _ = (&key, &code);
+  unsafe { f(api.backend_data, window_id, &raw) }
 }
 
 /// A menu item in an application menu template.

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -29,7 +29,7 @@ pub use mouse::*;
 /// (`github.com/denoland/laufey/releases/tag/v{VERSION}`).
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub const LAUFEY_API_VERSION: u32 = 34;
+pub const LAUFEY_API_VERSION: u32 = 35;
 
 /// Creation-time window style flags for [`Window::new_with_options`].
 /// Mirror the `LAUFEY_WINDOW_FLAG_*` constants in `laufey.h`.
@@ -830,6 +830,17 @@ impl Window {
     (width, height)
   }
 
+  /// Physical pixels per DIP for this window (`window.devicePixelRatio`).
+  /// Returns `1.0` when the backend does not report a scale.
+  pub fn get_scale_factor(&self) -> f64 {
+    let api = api();
+    if let Some(f) = api.get_window_scale_factor {
+      unsafe { f(api.backend_data, self.id) }
+    } else {
+      1.0
+    }
+  }
+
   pub fn position(self, x: i32, y: i32) -> Self {
     self.set_position(x, y);
     self
@@ -850,6 +861,20 @@ impl Window {
       unsafe { f(api.backend_data, self.id, &mut x, &mut y) };
     }
     (x, y)
+  }
+
+  /// Top-left of the content view in screen DIP. Falls back to
+  /// [`Window::get_position`] when the backend does not report it.
+  pub fn get_inner_position(&self) -> (i32, i32) {
+    let api = api();
+    if let Some(f) = api.get_window_inner_position {
+      let mut x: c_int = 0;
+      let mut y: c_int = 0;
+      unsafe { f(api.backend_data, self.id, &mut x, &mut y) };
+      (x, y)
+    } else {
+      self.get_position()
+    }
   }
 
   pub fn resizable(self, resizable: bool) -> Self {

--- a/cef/src/runtime_loader.cc
+++ b/cef/src/runtime_loader.cc
@@ -281,6 +281,42 @@ static void Backend_GetWindowSize(void* data, uint32_t window_id, int* width,
     *height = h;
 }
 
+static void Backend_GetWindowOuterSize(void* data, uint32_t window_id,
+                                       int* width, int* height) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  CefRefPtr<CefBrowser> browser = loader->GetBrowserForWindow(window_id);
+  int w = 0, h = 0;
+  if (browser) {
+    cef_invoke_sync([&] {
+      auto browser_view = CefBrowserView::GetForBrowser(browser);
+      if (!browser_view)
+        return;
+      auto window = browser_view->GetWindow();
+      if (!window)
+        return;
+#ifdef _WIN32
+      HWND hwnd = window->GetWindowHandle();
+      RECT rect;
+      if (hwnd && GetWindowRect(hwnd, &rect)) {
+        w = rect.right - rect.left;
+        h = rect.bottom - rect.top;
+        return;
+      }
+#elif defined(__APPLE__)
+      if (GetNSWindowOuterSize(window->GetWindowHandle(), &w, &h))
+        return;
+#endif
+      CefSize size = window->GetSize();
+      w = size.width;
+      h = size.height;
+    });
+  }
+  if (width)
+    *width = w;
+  if (height)
+    *height = h;
+}
+
 static void Backend_SetWindowPosition(void* data, uint32_t window_id, int x,
                                       int y) {
   RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
@@ -1799,6 +1835,42 @@ static bool Backend_TestClickMenuItem(void* /*data*/, const char* item_id) {
   return laufey_common::TestClickMenuItem(item_id);
 }
 
+static void InjectKey(void* ctx, uint32_t window_id, int state, const char* key,
+                      const char* code, uint32_t modifiers, bool repeat) {
+  static_cast<RuntimeLoader*>(ctx)->DispatchKeyboardEvent(
+      window_id, state, key, code, modifiers, repeat);
+}
+static void InjectClick(void* ctx, uint32_t window_id, int state, int button,
+                        double x, double y, uint32_t modifiers,
+                        int32_t click_count) {
+  static_cast<RuntimeLoader*>(ctx)->DispatchMouseClickEvent(
+      window_id, state, button, x, y, modifiers, click_count);
+}
+static void InjectMove(void* ctx, uint32_t window_id, double x, double y,
+                       uint32_t modifiers) {
+  static_cast<RuntimeLoader*>(ctx)->DispatchMouseMoveEvent(window_id, x, y,
+                                                           modifiers);
+}
+static void InjectWheel(void* ctx, uint32_t window_id, double delta_x,
+                        double delta_y, double x, double y, uint32_t modifiers,
+                        int32_t delta_mode) {
+  static_cast<RuntimeLoader*>(ctx)->DispatchWheelEvent(
+      window_id, delta_x, delta_y, x, y, modifiers, delta_mode);
+}
+static void InjectEnterLeave(void* ctx, uint32_t window_id, int entered,
+                             double x, double y, uint32_t modifiers) {
+  static_cast<RuntimeLoader*>(ctx)->DispatchCursorEnterLeaveEvent(
+      window_id, entered, x, y, modifiers);
+}
+
+static bool Backend_TestInjectInput(void* data, uint32_t window_id,
+                                    const laufey_test_input_t* event) {
+  laufey_common::TestInjectSink sink = {
+      InjectKey, InjectClick, InjectMove, InjectWheel, InjectEnterLeave, data,
+  };
+  return laufey_common::TestInjectInput(window_id, event, sink);
+}
+
 void RuntimeLoader::InitializeBackendApi() {
   memset(&backend_api_, 0, sizeof(backend_api_));
   backend_api_.version = LAUFEY_API_VERSION;
@@ -1815,6 +1887,7 @@ void RuntimeLoader::InitializeBackendApi() {
   backend_api_.quit = Backend_Quit;
   backend_api_.set_window_size = Backend_SetWindowSize;
   backend_api_.get_window_size = Backend_GetWindowSize;
+  backend_api_.get_window_outer_size = Backend_GetWindowOuterSize;
   backend_api_.set_window_position = Backend_SetWindowPosition;
   backend_api_.get_window_position = Backend_GetWindowPosition;
   backend_api_.get_window_inner_position = Backend_GetWindowInnerPosition;
@@ -1875,6 +1948,7 @@ void RuntimeLoader::InitializeBackendApi() {
   backend_api_.set_move_handler = Backend_SetMoveHandler;
   backend_api_.set_close_requested_handler = Backend_SetCloseRequestedHandler;
   backend_api_.test_trigger_close_requested = Backend_TestTriggerCloseRequested;
+  backend_api_.test_inject_input = Backend_TestInjectInput;
 
   backend_api_.poll_js_calls = [](void* data) {
     RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);

--- a/cef/src/runtime_loader.cc
+++ b/cef/src/runtime_loader.cc
@@ -31,6 +31,7 @@
 #include "include/cef_registration.h"
 #include "include/cef_task.h"
 #include "include/views/cef_browser_view.h"
+#include "include/views/cef_display.h"
 #include "include/views/cef_window.h"
 #include "include/wrapper/cef_closure_task.h"
 #include "include/wrapper/cef_helpers.h"
@@ -324,6 +325,27 @@ static void Backend_GetWindowPosition(void* data, uint32_t window_id, int* x,
     *y = py;
 }
 
+static void Backend_GetWindowInnerPosition(void* data, uint32_t window_id,
+                                           int* x, int* y) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  CefRefPtr<CefBrowser> browser = loader->GetBrowserForWindow(window_id);
+  int px = 0, py = 0;
+  if (browser) {
+    cef_invoke_sync([&] {
+      auto browser_view = CefBrowserView::GetForBrowser(browser);
+      if (browser_view) {
+        CefRect bounds = browser_view->GetBoundsInScreen();
+        px = bounds.x;
+        py = bounds.y;
+      }
+    });
+  }
+  if (x)
+    *x = px;
+  if (y)
+    *y = py;
+}
+
 static void Backend_SetResizable(void* data, uint32_t window_id,
                                  bool resizable) {
   RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
@@ -501,6 +523,26 @@ static double Backend_GetWindowOpacity(void* data, uint32_t window_id) {
 #elif defined(__linux__)
       result = GetLinuxWindowOpacity(window->GetWindowHandle());
 #endif
+    });
+  }
+  return result;
+}
+
+static double Backend_GetWindowScaleFactor(void* data, uint32_t window_id) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  CefRefPtr<CefBrowser> browser = loader->GetBrowserForWindow(window_id);
+  double result = 1.0;
+  if (browser) {
+    cef_invoke_sync([&] {
+      auto browser_view = CefBrowserView::GetForBrowser(browser);
+      if (!browser_view)
+        return;
+      auto window = browser_view->GetWindow();
+      if (!window)
+        return;
+      auto display = window->GetDisplay();
+      if (display)
+        result = display->GetDeviceScaleFactor();
     });
   }
   return result;
@@ -1775,12 +1817,14 @@ void RuntimeLoader::InitializeBackendApi() {
   backend_api_.get_window_size = Backend_GetWindowSize;
   backend_api_.set_window_position = Backend_SetWindowPosition;
   backend_api_.get_window_position = Backend_GetWindowPosition;
+  backend_api_.get_window_inner_position = Backend_GetWindowInnerPosition;
   backend_api_.set_resizable = Backend_SetResizable;
   backend_api_.is_resizable = Backend_IsResizable;
   backend_api_.set_always_on_top = Backend_SetAlwaysOnTop;
   backend_api_.is_always_on_top = Backend_IsAlwaysOnTop;
   backend_api_.set_window_opacity = Backend_SetWindowOpacity;
   backend_api_.get_window_opacity = Backend_GetWindowOpacity;
+  backend_api_.get_window_scale_factor = Backend_GetWindowScaleFactor;
   backend_api_.set_click_passthrough = Backend_SetClickPassthrough;
   backend_api_.is_click_passthrough = Backend_IsClickPassthrough;
   backend_api_.set_click_passthrough_forward =

--- a/cef/src/runtime_loader.h
+++ b/cef/src/runtime_loader.h
@@ -511,6 +511,7 @@ bool IsNSWindowResizable(void* cef_handle);
 // Overall window opacity in [0.0, 1.0] via NSWindow.alphaValue.
 void SetNSWindowOpacity(void* cef_handle, double opacity);
 double GetNSWindowOpacity(void* cef_handle);
+bool GetNSWindowOuterSize(void* cef_handle, int* width, int* height);
 // Click passthrough via NSWindow.ignoresMouseEvents: while enabled all mouse
 // input falls through to whatever is beneath the window.
 void SetNSWindowClickPassthrough(void* cef_handle, bool enabled);

--- a/cef/src/runtime_loader_mac.mm
+++ b/cef/src/runtime_loader_mac.mm
@@ -61,6 +61,19 @@ double GetNSWindowOpacity(void* cef_handle) {
   return 1.0;
 }
 
+bool GetNSWindowOuterSize(void* cef_handle, int* width, int* height) {
+  NSView* view = (__bridge NSView*)cef_handle;
+  NSWindow* nswindow = [view window];
+  if (!nswindow)
+    return false;
+  NSRect frame = [nswindow frame];
+  if (width)
+    *width = (int)frame.size.width;
+  if (height)
+    *height = (int)frame.size.height;
+  return true;
+}
+
 void SetNSWindowClickPassthrough(void* cef_handle, bool enabled) {
   NSView* view = (__bridge NSView*)cef_handle;
   NSWindow* nswindow = [view window];

--- a/docs/c-abi.md
+++ b/docs/c-abi.md
@@ -50,6 +50,8 @@ The pointers group into:
   `set_window_opacity`/`get_window_opacity` (whole-window alpha, API ≥ 28),
   `get_window_scale_factor` (`window.devicePixelRatio`, API ≥ 35),
   `get_window_inner_position` (content-view origin, API ≥ 35),
+  `get_window_outer_size` (`window.outerWidth` / `outerHeight`, API ≥ 35),
+  `test_inject_input` (synthetic pointer / key / wheel, API ≥ 35),
   `show`/`hide`/`is_visible`, `focus`, `quit`, `post_ui_task`.
 - **Value marshalling** — the `value_*` family (below).
 - **JavaScript interop** — `set_js_call_handler`, `js_call_respond`,

--- a/docs/c-abi.md
+++ b/docs/c-abi.md
@@ -6,7 +6,7 @@ It defines the boundary between a **backend** (a native executable embedding a
 browser engine) and a **runtime** (a shared library holding the application
 logic). The backend implements the ABI; the runtime consumes it.
 
-`LAUFEY_API_VERSION` (currently `31`) versions the contract. The `version` field
+`LAUFEY_API_VERSION` (currently `35`) versions the contract. The `version` field
 on the API table lets a runtime detect the backend's vintage and avoid calling
 function pointers a backend predates (older backends leave new pointers `NULL`).
 
@@ -48,6 +48,8 @@ The pointers group into:
   size/position get+set, `set_resizable`/`is_resizable`,
   `set_always_on_top`/`is_always_on_top`,
   `set_window_opacity`/`get_window_opacity` (whole-window alpha, API ≥ 28),
+  `get_window_scale_factor` (`window.devicePixelRatio`, API ≥ 35),
+  `get_window_inner_position` (content-view origin, API ≥ 35),
   `show`/`hide`/`is_visible`, `focus`, `quit`, `post_ui_task`.
 - **Value marshalling** — the `value_*` family (below).
 - **JavaScript interop** — `set_js_call_handler`, `js_call_respond`,

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -404,14 +404,25 @@ but ride the pre-existing `native-e2e` CI exclusions for those combos (`§`
 status note above) — not gated by this change, but not covered by CI for it
 either.
 
+**Implemented (API 35, same version as scale / inner-position — unreleased):**
+
+```c
+// Post a synthetic input event through the same dispatch a real OS event
+// uses. Wheel deltas are DOM-signed (positive Y is scroll down).
+bool (*test_inject_input)(void* backend_data, uint32_t window_id,
+                          const laufey_test_input_t* event);
+```
+
+Winit runs the `WindowEvent` path (`modifier_key_edges`, `next_click_count`,
+`winit_scroll_to_dom`, enter-waits-for-move). CEF / WebView call `Dispatch*`
+with already-DOM values (click_count 1). The capi exposes
+`laufey::test_inject_input`. `native_e2e` capability-probes the hook.
+
 **Not yet added** (future hooks, same append-and-`N/A` pattern):
 
 ```c
 // Serialize the menu the backend ACTUALLY built, for template->native readback.
 laufey_value_t* (*test_dump_menu)(void* backend_data, int surface, uint32_t id);
-// Post a synthetic input event for the mouse/keyboard/wheel/cursor handlers.
-bool (*test_inject_input)(void* backend_data, uint32_t window_id,
-                          const laufey_test_input_t* event);
 ```
 
 Note the contrast with macOS self-AX (`§7.2`): reading the OS's view of a widget

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -146,7 +146,8 @@ getter. No display-server introspection needed.
 - Window: `set_window_size`/`get_window_size`,
   `set_window_position`/`get_window_position`, `set_resizable`/`is_resizable`,
   `set_always_on_top`/`is_always_on_top`, `show`/`hide`/`is_visible`,
-  `set_window_opacity`/`get_window_opacity`.
+  `set_window_opacity`/`get_window_opacity`,
+  `get_window_scale_factor`.
 - Clipboard: `write_clipboard_text` → `read_clipboard_text` (round-trips through
   the real OS clipboard).
 - Handles: `get_window_handle` / `get_display_handle` / `get_window_handle_type`

--- a/docs/window-management.md
+++ b/docs/window-management.md
@@ -18,6 +18,7 @@ let win = Window::new(800, 600)
 
 win.set_size(1024, 768);
 let (width, height) = win.get_size();
+let scale = win.get_scale_factor(); // window.devicePixelRatio
 win.focus();
 win.hide();
 ```
@@ -28,7 +29,11 @@ operating-system chrome), whether it is a non-activating panel that does not
 steal keyboard focus, and whether it has a transparent background. You set those
 through `Window::new_with_options`. Everything else is a live setter. All
 positions and sizes are expressed in density-independent pixels with the origin
-at the top-left of the screen. The Winit backend can create and manage windows,
+at the top-left of the screen. `Window::get_scale_factor` is the physical-to-DIP
+ratio for that window (`window.devicePixelRatio`); it updates when the window
+moves to another display. `get_inner_position` is the content-view origin
+(`get_position` plus title-bar chrome), so `inner + client` is
+`MouseEvent.screenX` / `screenY`. The Winit backend can create and manage windows,
 but because it has no web engine it cannot navigate to a URL or execute
 JavaScript.
 

--- a/examples/native_e2e/src/lib.rs
+++ b/examples/native_e2e/src/lib.rs
@@ -12,20 +12,26 @@
 //!
 //! This covers Layer 0 (in-process readback + event-callback round-trips),
 //! menu/tray *click* round-trips via the `test_click_menu_item` C ABI hook
-//! (API 30+; `N/A` on backends without it), and the close-handler round-trip
-//! via `test_trigger_close_requested` (API 31+; `N/A` on backends without
-//! it). OS-observer *structure* checks
-//! (Layer 1: the Linux D-Bus driver; macOS/Windows pending a backend hook)
-//! live outside this runtime. See docs/e2e-testing.md.
+//! (API 30+; `N/A` on backends without it), the close-handler round-trip
+//! via `test_trigger_close_requested` (API 31+), and synthetic pointer /
+//! key / wheel events via `test_inject_input` (API 35). OS-observer
+//! *structure* checks (Layer 1: the Linux D-Bus driver; macOS/Windows
+//! pending a backend hook) live outside this runtime. See
+//! docs/e2e-testing.md.
 //!
 //! Mirrors the execution model of `examples/cef_e2e` (tokio runtime, spawned
 //! event-loop pump, PASS/FAIL + exit code) so the existing runtime loader drives
 //! it unchanged.
 
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
-use laufey::{MenuItem, TrayIcon, Window};
+use laufey::{
+  CursorEnterLeaveEvent, KeyState, KeyboardEvent, MenuItem, MouseButton,
+  MouseButtonState, MouseClickEvent, MouseMoveEvent, TestInput, TrayIcon,
+  WheelDeltaMode, WheelEvent, Window, WindowOptions, LAUFEY_MOD_SHIFT,
+  LAUFEY_MOUSE_BUTTON_LEFT, LAUFEY_WHEEL_DELTA_LINE,
+};
 
 static FAILED: AtomicBool = AtomicBool::new(false);
 
@@ -52,6 +58,56 @@ fn check(name: &str, ok: bool) {
 /// Capability absent on this backend — informational, never fails the run.
 fn na(name: &str) {
   eprintln!("[e2e] N/A  {name}");
+}
+
+/// Decorated macOS / Windows chrome puts the content origin below (and
+/// usually a bit to the right of) the frame origin. Linux reports the
+/// compositor's frame as the content, so the two coincide.
+fn expect_title_bar_offset() -> bool {
+  cfg!(any(target_os = "macos", target_os = "windows"))
+}
+
+fn check_inner_vs_frame(
+  name: &str,
+  frame: (i32, i32),
+  inner: (i32, i32),
+  expect_chrome: bool,
+) {
+  if frame == (0, 0) && inner == (0, 0) {
+    na(&format!("{name} (window not placed yet)"));
+    return;
+  }
+  // Winit's get_position only reports a not-yet-applied set, so after
+  // realize the frame reads as (0, 0) while inner is the real content
+  // origin. That is a getter limitation, not a chrome-offset bug.
+  if frame == (0, 0) && inner != (0, 0) {
+    na(&format!("{name} (frame origin not readable)"));
+    return;
+  }
+  let dx = inner.0 - frame.0;
+  let dy = inner.1 - frame.1;
+  if expect_chrome {
+    check(name, dy > 0 && dx >= 0 && dy > dx);
+  } else {
+    check(name, dx == 0 && dy == 0);
+  }
+}
+
+fn check_outer_vs_inner(
+  name: &str,
+  inner: (i32, i32),
+  outer: (i32, i32),
+  expect_chrome: bool,
+) {
+  if inner == (0, 0) && outer == (0, 0) {
+    na(&format!("{name} (size not available yet)"));
+    return;
+  }
+  if expect_chrome {
+    check(name, outer.0 >= inner.0 && outer.1 > inner.1);
+  } else {
+    check(name, outer == inner);
+  }
 }
 
 async fn wait_for<F: Fn() -> bool>(f: F, attempts: u32, step_ms: u64) -> bool {
@@ -126,6 +182,56 @@ fn e2e_main() {
 
     check("window id is nonzero", win.id() != 0);
 
+    // Constructor-time getters must not wait for the OS window: JS can
+    // read them from the constructor, and the winit backend creates the
+    // NSWindow / HWND asynchronously. Seeded DPR used to stay 1.0 until
+    // the first Resized; inner position used to be the frame origin.
+    let early_scale = win.get_scale_factor();
+    check("early scale factor is positive", early_scale > 0.0);
+    let (early_w, early_h) = win.get_size();
+    check(
+      "constructor size is readable immediately",
+      (early_w - 800).abs() <= 2 && (early_h - 600).abs() <= 2,
+    );
+
+    let decorated = Window::new(400, 300).title("native-e2e-chrome");
+    decorated.set_position(240, 160);
+    check_inner_vs_frame(
+      "decorated inner is offset by the title bar",
+      decorated.get_position(),
+      decorated.get_inner_position(),
+      expect_title_bar_offset(),
+    );
+
+    let frameless = Window::new_with_options(
+      200,
+      150,
+      WindowOptions {
+        frameless: true,
+        ..WindowOptions::default()
+      },
+    )
+    .title("native-e2e-frameless");
+    frameless.set_position(300, 200);
+    check_inner_vs_frame(
+      "frameless inner matches the frame origin",
+      frameless.get_position(),
+      frameless.get_inner_position(),
+      false,
+    );
+    check_outer_vs_inner(
+      "decorated outer is larger than the content",
+      decorated.get_size(),
+      decorated.get_outer_size(),
+      expect_title_bar_offset(),
+    );
+    check_outer_vs_inner(
+      "frameless outer matches the content",
+      frameless.get_size(),
+      frameless.get_outer_size(),
+      false,
+    );
+
     // ---- race probe: native handle immediately after creation ------------
     // Regression guard for denoland/deno#35785. The winit/raw backend creates
     // the OS window asynchronously, so reading the handle *right now* — with no
@@ -147,6 +253,244 @@ fn e2e_main() {
 
     // Give the backend a moment to realize the window on screen.
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let settled_scale = win.get_scale_factor();
+    check("scale factor is still positive after realize", settled_scale > 0.0);
+    check(
+      "scale factor is stable from the constructor",
+      (early_scale - settled_scale).abs() < 0.01,
+    );
+    let (settled_w, settled_h) = win.get_size();
+    check(
+      "constructor size survives realize",
+      (settled_w - 800).abs() <= 2 && (settled_h - 600).abs() <= 2,
+    );
+
+    // After realize, WebView / CEF can still compare inner vs frame from
+    // the live window. Winit's get_position only reflects a pending set,
+    // so a (0, 0) frame with a nonzero inner is N/A rather than a fail.
+    check_inner_vs_frame(
+      "settled decorated inner is offset by the title bar",
+      decorated.get_position(),
+      decorated.get_inner_position(),
+      expect_title_bar_offset(),
+    );
+    check_inner_vs_frame(
+      "settled frameless inner matches the frame origin",
+      frameless.get_position(),
+      frameless.get_inner_position(),
+      false,
+    );
+    check_outer_vs_inner(
+      "settled decorated outer is larger than the content",
+      decorated.get_size(),
+      decorated.get_outer_size(),
+      expect_title_bar_offset(),
+    );
+    check_outer_vs_inner(
+      "settled frameless outer matches the content",
+      frameless.get_size(),
+      frameless.get_outer_size(),
+      false,
+    );
+
+    // ---- test_inject_input ----------------------------------------------
+    let last_key = Arc::new(Mutex::new(None::<KeyboardEvent>));
+    let last_click = Arc::new(Mutex::new(None::<MouseClickEvent>));
+    let last_move = Arc::new(Mutex::new(None::<MouseMoveEvent>));
+    let last_wheel = Arc::new(Mutex::new(None::<WheelEvent>));
+    let last_enter = Arc::new(Mutex::new(None::<CursorEnterLeaveEvent>));
+    let input_win = {
+      let lk = last_key.clone();
+      let lc = last_click.clone();
+      let lm = last_move.clone();
+      let lw = last_wheel.clone();
+      let le = last_enter.clone();
+      Window::new(200, 150)
+        .title("native-e2e-input")
+        .on_keyboard_event(move |e| *lk.lock().unwrap() = Some(e))
+        .on_mouse_click(move |e| *lc.lock().unwrap() = Some(e))
+        .on_mouse_move(move |e| *lm.lock().unwrap() = Some(e))
+        .on_wheel(move |e| *lw.lock().unwrap() = Some(e))
+        .on_cursor_enter_leave(move |e| *le.lock().unwrap() = Some(e))
+    };
+    let input_id = input_win.id();
+
+    if !laufey::test_inject_input(
+      input_id,
+      &TestInput::MouseMove {
+        x: 10.0,
+        y: 10.0,
+        modifiers: 0,
+      },
+    ) {
+      na("test_inject_input (backend has no hook)");
+    } else {
+      check(
+        "inject mousemove reaches on_mouse_move",
+        last_move
+          .lock()
+          .unwrap()
+          .as_ref()
+          .is_some_and(|e| (e.x - 10.0).abs() < 0.5 && (e.y - 10.0).abs() < 0.5),
+      );
+
+      // Reset hover so the next enter is pending until a real coordinate.
+      let _ = laufey::test_inject_input(
+        input_id,
+        &TestInput::CursorLeave {
+          x: 10.0,
+          y: 10.0,
+          modifiers: 0,
+        },
+      );
+      *last_enter.lock().unwrap() = None;
+      let _ = laufey::test_inject_input(
+        input_id,
+        &TestInput::CursorEnter {
+          x: 0.0,
+          y: 0.0,
+          modifiers: 0,
+        },
+      );
+      let enter_before_move = last_enter.lock().unwrap().clone();
+      let _ = laufey::test_inject_input(
+        input_id,
+        &TestInput::MouseMove {
+          x: 40.0,
+          y: 50.0,
+          modifiers: 0,
+        },
+      );
+      let enter_after_move = last_enter.lock().unwrap().clone();
+      match (enter_before_move, enter_after_move) {
+        (None, Some(e)) if e.entered && (e.x - 40.0).abs() < 0.5 && (e.y - 50.0).abs() < 0.5 => {
+          check("mouseenter waits for the first move", true);
+        }
+        (Some(e), _) if e.entered && e.x == 0.0 && e.y == 0.0 => {
+          na("mouseenter waits for the first move (backend injects enter immediately)");
+        }
+        _ => check("mouseenter waits for the first move", false),
+      }
+
+      *last_click.lock().unwrap() = None;
+      let _ = laufey::test_inject_input(
+        input_id,
+        &TestInput::MouseButton {
+          button: LAUFEY_MOUSE_BUTTON_LEFT,
+          pressed: true,
+          x: 40.0,
+          y: 50.0,
+          modifiers: 0,
+        },
+      );
+      let _ = laufey::test_inject_input(
+        input_id,
+        &TestInput::MouseButton {
+          button: LAUFEY_MOUSE_BUTTON_LEFT,
+          pressed: false,
+          x: 40.0,
+          y: 50.0,
+          modifiers: 0,
+        },
+      );
+      let first = last_click.lock().unwrap().clone();
+      check(
+        "inject click.detail is 1",
+        first.as_ref().is_some_and(|e| {
+          e.state == MouseButtonState::Released
+            && e.button == MouseButton::Left
+            && e.click_count == 1
+        }),
+      );
+
+      *last_click.lock().unwrap() = None;
+      let _ = laufey::test_inject_input(
+        input_id,
+        &TestInput::MouseButton {
+          button: LAUFEY_MOUSE_BUTTON_LEFT,
+          pressed: true,
+          x: 40.0,
+          y: 50.0,
+          modifiers: 0,
+        },
+      );
+      match last_click.lock().unwrap().as_ref().map(|e| e.click_count) {
+        Some(2) => check("inject second nearby press is click.detail 2", true),
+        Some(1) => na(
+          "inject second nearby press is click.detail 2 (backend inject does not track multi-click)",
+        ),
+        _ => check("inject second nearby press is click.detail 2", false),
+      }
+
+      *last_wheel.lock().unwrap() = None;
+      let _ = laufey::test_inject_input(
+        input_id,
+        &TestInput::Wheel {
+          delta_x: 0.0,
+          delta_y: -1.0,
+          delta_mode: LAUFEY_WHEEL_DELTA_LINE,
+          x: 40.0,
+          y: 50.0,
+          modifiers: 0,
+        },
+      );
+      check(
+        "inject line-scroll up is DOM-negative deltaY",
+        last_wheel.lock().unwrap().as_ref().is_some_and(|e| {
+          e.delta_y < 0.0 && e.delta_mode == WheelDeltaMode::Line
+        }),
+      );
+
+      *last_key.lock().unwrap() = None;
+      let _ = laufey::test_inject_input(
+        input_id,
+        &TestInput::Key {
+          key: "a".into(),
+          code: "KeyA".into(),
+          pressed: true,
+          repeat: false,
+          modifiers: 0,
+        },
+      );
+      check(
+        "inject KeyA reaches on_keyboard_event",
+        last_key.lock().unwrap().as_ref().is_some_and(|e| {
+          e.state == KeyState::Pressed && e.key == "a" && e.code == "KeyA"
+        }),
+      );
+
+      *last_key.lock().unwrap() = None;
+      let _ = laufey::test_inject_input(
+        input_id,
+        &TestInput::Modifiers {
+          modifiers: LAUFEY_MOD_SHIFT,
+        },
+      );
+      check(
+        "inject Shift modifiers emit keydown Shift/ShiftLeft",
+        last_key.lock().unwrap().as_ref().is_some_and(|e| {
+          e.state == KeyState::Pressed
+            && e.key == "Shift"
+            && e.code == "ShiftLeft"
+            && e.modifiers.shift
+        }),
+      );
+      *last_key.lock().unwrap() = None;
+      let _ = laufey::test_inject_input(
+        input_id,
+        &TestInput::Modifiers { modifiers: 0 },
+      );
+      check(
+        "inject Shift release emits keyup",
+        last_key.lock().unwrap().as_ref().is_some_and(|e| {
+          e.state == KeyState::Released
+            && e.key == "Shift"
+            && !e.modifiers.shift
+        }),
+      );
+    }
+    let _ = &input_win;
 
     // ---- A. direct state readback ---------------------------------------
     win.set_size(640, 480);

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -156,6 +156,15 @@ static void Backend_GetWindowSize(void* data, uint32_t window_id, int* width,
   }
 }
 
+static void Backend_GetWindowOuterSize(void* data, uint32_t window_id,
+                                       int* width, int* height) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  LaufeyBackend* backend = loader->GetBackend();
+  if (backend) {
+    backend->GetWindowOuterSize(window_id, width, height);
+  }
+}
+
 static void Backend_SetWindowPosition(void* data, uint32_t window_id, int x,
                                       int y) {
   RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
@@ -698,6 +707,42 @@ static bool Backend_TestClickMenuItem(void* /*data*/, const char* item_id) {
   return laufey_common::TestClickMenuItem(item_id);
 }
 
+static void InjectKey(void* ctx, uint32_t window_id, int state, const char* key,
+                      const char* code, uint32_t modifiers, bool repeat) {
+  static_cast<RuntimeLoader*>(ctx)->DispatchKeyboardEvent(
+      window_id, state, key, code, modifiers, repeat);
+}
+static void InjectClick(void* ctx, uint32_t window_id, int state, int button,
+                        double x, double y, uint32_t modifiers,
+                        int32_t click_count) {
+  static_cast<RuntimeLoader*>(ctx)->DispatchMouseClickEvent(
+      window_id, state, button, x, y, modifiers, click_count);
+}
+static void InjectMove(void* ctx, uint32_t window_id, double x, double y,
+                       uint32_t modifiers) {
+  static_cast<RuntimeLoader*>(ctx)->DispatchMouseMoveEvent(window_id, x, y,
+                                                           modifiers);
+}
+static void InjectWheel(void* ctx, uint32_t window_id, double delta_x,
+                        double delta_y, double x, double y, uint32_t modifiers,
+                        int32_t delta_mode) {
+  static_cast<RuntimeLoader*>(ctx)->DispatchWheelEvent(
+      window_id, delta_x, delta_y, x, y, modifiers, delta_mode);
+}
+static void InjectEnterLeave(void* ctx, uint32_t window_id, int entered,
+                             double x, double y, uint32_t modifiers) {
+  static_cast<RuntimeLoader*>(ctx)->DispatchCursorEnterLeaveEvent(
+      window_id, entered, x, y, modifiers);
+}
+
+static bool Backend_TestInjectInput(void* data, uint32_t window_id,
+                                    const laufey_test_input_t* event) {
+  laufey_common::TestInjectSink sink = {
+      InjectKey, InjectClick, InjectMove, InjectWheel, InjectEnterLeave, data,
+  };
+  return laufey_common::TestInjectInput(window_id, event, sink);
+}
+
 static void Backend_SetTrayMenu(void* data, uint32_t tray_id,
                                 laufey_value_t* menu_template,
                                 laufey_menu_click_fn on_click,
@@ -786,6 +831,7 @@ void RuntimeLoader::InitializeBackendApi() {
   backend_api_.quit = Backend_Quit;
   backend_api_.set_window_size = Backend_SetWindowSize;
   backend_api_.get_window_size = Backend_GetWindowSize;
+  backend_api_.get_window_outer_size = Backend_GetWindowOuterSize;
   backend_api_.set_window_position = Backend_SetWindowPosition;
   backend_api_.get_window_position = Backend_GetWindowPosition;
   backend_api_.get_window_inner_position = Backend_GetWindowInnerPosition;
@@ -852,6 +898,7 @@ void RuntimeLoader::InitializeBackendApi() {
   backend_api_.close_window = Backend_CloseWindow;
   backend_api_.set_close_requested_handler = Backend_SetCloseRequestedHandler;
   backend_api_.test_trigger_close_requested = Backend_TestTriggerCloseRequested;
+  backend_api_.test_inject_input = Backend_TestInjectInput;
   backend_api_.set_page_load_handler = Backend_SetPageLoadHandler;
   backend_api_.show_dialog = Backend_ShowDialog;
   backend_api_.string_free = Backend_StringFree;

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -174,6 +174,15 @@ static void Backend_GetWindowPosition(void* data, uint32_t window_id, int* x,
   }
 }
 
+static void Backend_GetWindowInnerPosition(void* data, uint32_t window_id,
+                                           int* x, int* y) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  LaufeyBackend* backend = loader->GetBackend();
+  if (backend) {
+    backend->GetWindowInnerPosition(window_id, x, y);
+  }
+}
+
 static void Backend_SetResizable(void* data, uint32_t window_id,
                                  bool resizable) {
   RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
@@ -224,6 +233,15 @@ static double Backend_GetWindowOpacity(void* data, uint32_t window_id) {
   LaufeyBackend* backend = loader->GetBackend();
   if (backend) {
     return backend->GetWindowOpacity(window_id);
+  }
+  return 1.0;
+}
+
+static double Backend_GetWindowScaleFactor(void* data, uint32_t window_id) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  LaufeyBackend* backend = loader->GetBackend();
+  if (backend) {
+    return backend->GetWindowScaleFactor(window_id);
   }
   return 1.0;
 }
@@ -770,12 +788,14 @@ void RuntimeLoader::InitializeBackendApi() {
   backend_api_.get_window_size = Backend_GetWindowSize;
   backend_api_.set_window_position = Backend_SetWindowPosition;
   backend_api_.get_window_position = Backend_GetWindowPosition;
+  backend_api_.get_window_inner_position = Backend_GetWindowInnerPosition;
   backend_api_.set_resizable = Backend_SetResizable;
   backend_api_.is_resizable = Backend_IsResizable;
   backend_api_.set_always_on_top = Backend_SetAlwaysOnTop;
   backend_api_.is_always_on_top = Backend_IsAlwaysOnTop;
   backend_api_.set_window_opacity = Backend_SetWindowOpacity;
   backend_api_.get_window_opacity = Backend_GetWindowOpacity;
+  backend_api_.get_window_scale_factor = Backend_GetWindowScaleFactor;
   backend_api_.set_click_passthrough = Backend_SetClickPassthrough;
   backend_api_.is_click_passthrough = Backend_IsClickPassthrough;
   backend_api_.set_click_passthrough_forward =

--- a/webview/src/runtime_loader.h
+++ b/webview/src/runtime_loader.h
@@ -389,8 +389,15 @@ class LaufeyBackend {
                          laufey_js_result_fn callback, void* callback_data) = 0;
   virtual void SetWindowSize(uint32_t window_id, int width, int height) = 0;
   virtual void GetWindowSize(uint32_t window_id, int* width, int* height) = 0;
+  // Chrome-inclusive size in the same space as GetWindowSize. Default is
+  // the content size (no client chrome).
+  virtual void GetWindowOuterSize(uint32_t window_id, int* width, int* height) {
+    GetWindowSize(window_id, width, height);
+  }
   // Physical pixels per DIP (`window.devicePixelRatio`). Default 1.0.
-  virtual double GetWindowScaleFactor(uint32_t /*window_id*/) { return 1.0; }
+  virtual double GetWindowScaleFactor(uint32_t /*window_id*/) {
+    return 1.0;
+  }
   virtual void SetWindowPosition(uint32_t window_id, int x, int y) = 0;
   virtual void GetWindowPosition(uint32_t window_id, int* x, int* y) = 0;
   // Content-view origin in the same space as GetWindowPosition. Default is

--- a/webview/src/runtime_loader.h
+++ b/webview/src/runtime_loader.h
@@ -389,8 +389,15 @@ class LaufeyBackend {
                          laufey_js_result_fn callback, void* callback_data) = 0;
   virtual void SetWindowSize(uint32_t window_id, int width, int height) = 0;
   virtual void GetWindowSize(uint32_t window_id, int* width, int* height) = 0;
+  // Physical pixels per DIP (`window.devicePixelRatio`). Default 1.0.
+  virtual double GetWindowScaleFactor(uint32_t /*window_id*/) { return 1.0; }
   virtual void SetWindowPosition(uint32_t window_id, int x, int y) = 0;
   virtual void GetWindowPosition(uint32_t window_id, int* x, int* y) = 0;
+  // Content-view origin in the same space as GetWindowPosition. Default is
+  // the frame origin (no chrome offset).
+  virtual void GetWindowInnerPosition(uint32_t window_id, int* x, int* y) {
+    GetWindowPosition(window_id, x, y);
+  }
   virtual void SetResizable(uint32_t window_id, bool resizable) = 0;
   virtual bool IsResizable(uint32_t window_id) = 0;
   virtual void SetAlwaysOnTop(uint32_t window_id, bool always_on_top) = 0;

--- a/webview/src/webview_ios.mm
+++ b/webview/src/webview_ios.mm
@@ -62,6 +62,9 @@ class WKWebViewIOSBackend : public LaufeyBackend {
     if (h)
       *h = (int)b.size.height;
   }
+  double GetWindowScaleFactor(uint32_t) override {
+    return (double)UIScreen.mainScreen.scale;
+  }
   void SetWindowPosition(uint32_t, int, int) override {}
   void GetWindowPosition(uint32_t, int* x, int* y) override {
     if (x)

--- a/webview/src/webview_linux.cc
+++ b/webview/src/webview_linux.cc
@@ -354,8 +354,10 @@ class WebKitGTKBackend : public LaufeyBackend {
   void Quit() override;
   void SetWindowSize(uint32_t window_id, int width, int height) override;
   void GetWindowSize(uint32_t window_id, int* width, int* height) override;
+  double GetWindowScaleFactor(uint32_t window_id) override;
   void SetWindowPosition(uint32_t window_id, int x, int y) override;
   void GetWindowPosition(uint32_t window_id, int* x, int* y) override;
+  void GetWindowInnerPosition(uint32_t window_id, int* x, int* y) override;
   void SetResizable(uint32_t window_id, bool resizable) override;
   bool IsResizable(uint32_t window_id) override;
   void SetAlwaysOnTop(uint32_t window_id, bool always_on_top) override;
@@ -945,6 +947,18 @@ void WebKitGTKBackend::SetWindowSize(uint32_t window_id, int width,
   });
 }
 
+double WebKitGTKBackend::GetWindowScaleFactor(uint32_t window_id) {
+  int scale = 1;
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      scale = gtk_widget_get_scale_factor(GTK_WIDGET(state->window));
+    }
+  });
+  return scale > 0 ? (double)scale : 1.0;
+}
+
 void WebKitGTKBackend::GetWindowSize(uint32_t window_id, int* width,
                                      int* height) {
   int w = 0, h = 0;
@@ -969,6 +983,24 @@ void WebKitGTKBackend::SetWindowPosition(uint32_t window_id, int x, int y) {
       gtk_window_move(GTK_WINDOW(state->window), x, y);
     }
   });
+}
+
+void WebKitGTKBackend::GetWindowInnerPosition(uint32_t window_id, int* x,
+                                              int* y) {
+  int wx = 0, wy = 0;
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state && state->webview) {
+      GdkWindow* gw = gtk_widget_get_window(GTK_WIDGET(state->webview));
+      if (gw)
+        gdk_window_get_origin(gw, &wx, &wy);
+    }
+  });
+  if (x)
+    *x = wx;
+  if (y)
+    *y = wy;
 }
 
 void WebKitGTKBackend::GetWindowPosition(uint32_t window_id, int* x, int* y) {

--- a/webview/src/webview_linux.cc
+++ b/webview/src/webview_linux.cc
@@ -354,6 +354,7 @@ class WebKitGTKBackend : public LaufeyBackend {
   void Quit() override;
   void SetWindowSize(uint32_t window_id, int width, int height) override;
   void GetWindowSize(uint32_t window_id, int* width, int* height) override;
+  void GetWindowOuterSize(uint32_t window_id, int* width, int* height) override;
   double GetWindowScaleFactor(uint32_t window_id) override;
   void SetWindowPosition(uint32_t window_id, int x, int y) override;
   void GetWindowPosition(uint32_t window_id, int* x, int* y) override;
@@ -967,6 +968,30 @@ void WebKitGTKBackend::GetWindowSize(uint32_t window_id, int* width,
     auto* state = GetWindow(window_id);
     if (state) {
       gtk_window_get_size(GTK_WINDOW(state->window), &w, &h);
+    }
+  });
+  if (width)
+    *width = w;
+  if (height)
+    *height = h;
+}
+
+void WebKitGTKBackend::GetWindowOuterSize(uint32_t window_id, int* width,
+                                          int* height) {
+  int w = 0, h = 0;
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      GdkWindow* gw = gtk_widget_get_window(GTK_WIDGET(state->window));
+      if (gw) {
+        GdkRectangle ext = {0, 0, 0, 0};
+        gdk_window_get_frame_extents(gw, &ext);
+        w = ext.width;
+        h = ext.height;
+      } else {
+        gtk_window_get_size(GTK_WINDOW(state->window), &w, &h);
+      }
     }
   });
   if (width)

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -601,6 +601,58 @@ inline std::string NSEventKeyCodeToCode(unsigned short keyCode) {
   return laufey_common::NSEventKeyToCode(keyCode);
 }
 
+// FlagsChanged has no `characters`. Map the hardware key to the Web `key`.
+std::string ModifierKeyFromKeyCode(unsigned short keyCode) {
+  switch (keyCode) {
+    case 56:
+    case 60:
+      return "Shift";
+    case 59:
+    case 62:
+      return "Control";
+    case 58:
+    case 61:
+      return "Alt";
+    case 54:
+    case 55:
+      return "Meta";
+    default:
+      return "";
+  }
+}
+
+bool ModifierFlagIsDown(unsigned short keyCode, NSEventModifierFlags flags) {
+  switch (keyCode) {
+    case 56:
+    case 60:
+      return (flags & NSEventModifierFlagShift) != 0;
+    case 59:
+    case 62:
+      return (flags & NSEventModifierFlagControl) != 0;
+    case 58:
+    case 61:
+      return (flags & NSEventModifierFlagOption) != 0;
+    case 54:
+    case 55:
+      return (flags & NSEventModifierFlagCommand) != 0;
+    default:
+      return false;
+  }
+}
+
+// NSEvent.clickCount is 0 on some mouse-up deliveries. Keep the press count
+// so `click.detail` matches a browser (1 for a single click).
+int32_t ResolveClickCount(int state, int32_t click_count) {
+  static int32_t last_click_count = 1;
+  if (state == LAUFEY_MOUSE_PRESSED) {
+    if (click_count < 1)
+      click_count = 1;
+    last_click_count = click_count;
+    return click_count;
+  }
+  return click_count >= 1 ? click_count : last_click_count;
+}
+
 uint32_t NSModifierFlagsToLaufey(NSEventModifierFlags flags) {
   uint32_t modifiers = 0;
   if (flags & NSEventModifierFlagShift)
@@ -717,12 +769,37 @@ void WKWebViewBackend::InstallGlobalMonitors() {
 
   keyboard_monitor_ = [NSEvent
       addLocalMonitorForEventsMatchingMask:(NSEventMaskKeyDown |
-                                            NSEventMaskKeyUp)
+                                            NSEventMaskKeyUp |
+                                            NSEventMaskFlagsChanged)
                                    handler:^NSEvent*(NSEvent* event) {
                                      NSWindow* win = [event window];
                                      uint32_t wid = LaufeyIdForNSWindow(win);
                                      if (wid == 0)
                                        return event;
+
+                                     uint32_t modifiers =
+                                         NSModifierFlagsToLaufey(
+                                             [event modifierFlags]);
+                                     if ([event type] ==
+                                         NSEventTypeFlagsChanged) {
+                                       unsigned short kc = [event keyCode];
+                                       std::string key =
+                                           ModifierKeyFromKeyCode(kc);
+                                       if (key.empty())
+                                         return event;
+                                       int state =
+                                           ModifierFlagIsDown(
+                                               kc, [event modifierFlags])
+                                               ? LAUFEY_KEY_PRESSED
+                                               : LAUFEY_KEY_RELEASED;
+                                       std::string code =
+                                           NSEventKeyCodeToCode(kc);
+                                       RuntimeLoader::GetInstance()
+                                           ->DispatchKeyboardEvent(
+                                               wid, state, key.c_str(),
+                                               code.c_str(), modifiers, false);
+                                       return event;
+                                     }
 
                                      int state =
                                          ([event type] == NSEventTypeKeyDown)
@@ -732,9 +809,6 @@ void WKWebViewBackend::InstallGlobalMonitors() {
                                          NSEventKeyToString(event);
                                      std::string code =
                                          NSEventKeyCodeToCode([event keyCode]);
-                                     uint32_t modifiers =
-                                         NSModifierFlagsToLaufey(
-                                             [event modifierFlags]);
                                      bool repeat = [event isARepeat];
 
                                      RuntimeLoader::GetInstance()
@@ -775,8 +849,8 @@ void WKWebViewBackend::InstallGlobalMonitors() {
                                      uint32_t modifiers =
                                          NSModifierFlagsToLaufey(
                                              [event modifierFlags]);
-                                     int32_t click_count =
-                                         (int32_t)[event clickCount];
+                                     int32_t click_count = ResolveClickCount(
+                                         state, (int32_t)[event clickCount]);
 
                                      NSPoint loc = [event locationInWindow];
                                      double x = loc.x;
@@ -1726,8 +1800,8 @@ void WKWebViewBackend::UpdateForwardMonitors() {
                                       uint32_t modifiers =
                                           NSModifierFlagsToLaufey(
                                               [event modifierFlags]);
-                                      int32_t click_count =
-                                          (int32_t)[event clickCount];
+                                      int32_t click_count = ResolveClickCount(
+                                          state, (int32_t)[event clickCount]);
 
                                       NSPoint local = [win
                                           convertPointFromScreen:screen_point];

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -62,8 +62,10 @@ class WKWebViewBackend : public LaufeyBackend {
   void Quit() override;
   void SetWindowSize(uint32_t window_id, int width, int height) override;
   void GetWindowSize(uint32_t window_id, int* width, int* height) override;
+  double GetWindowScaleFactor(uint32_t window_id) override;
   void SetWindowPosition(uint32_t window_id, int x, int y) override;
   void GetWindowPosition(uint32_t window_id, int* x, int* y) override;
+  void GetWindowInnerPosition(uint32_t window_id, int* x, int* y) override;
   void SetResizable(uint32_t window_id, bool resizable) override;
   bool IsResizable(uint32_t window_id) override;
   void SetAlwaysOnTop(uint32_t window_id, bool always_on_top) override;
@@ -1405,6 +1407,18 @@ void WKWebViewBackend::SetWindowSize(uint32_t window_id, int width,
   });
 }
 
+double WKWebViewBackend::GetWindowScaleFactor(uint32_t window_id) {
+  __block double result = 1.0;
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      result = (double)[state->window backingScaleFactor];
+    }
+  });
+  return result;
+}
+
 void WKWebViewBackend::GetWindowSize(uint32_t window_id, int* width,
                                      int* height) {
   __block int w = 0, h = 0;
@@ -1438,6 +1452,26 @@ void WKWebViewBackend::SetWindowPosition(uint32_t window_id, int x, int y) {
       }
     }
   });
+}
+
+void WKWebViewBackend::GetWindowInnerPosition(uint32_t window_id, int* x,
+                                              int* y) {
+  __block int px = 0, py = 0;
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      NSRect content =
+          [state->window contentRectForFrameRect:[state->window frame]];
+      px = static_cast<int>(content.origin.x);
+      py = static_cast<int>(PrimaryScreenHeight() - content.origin.y -
+                            content.size.height);
+    }
+  });
+  if (x)
+    *x = px;
+  if (y)
+    *y = py;
 }
 
 void WKWebViewBackend::GetWindowPosition(uint32_t window_id, int* x, int* y) {

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -62,6 +62,7 @@ class WKWebViewBackend : public LaufeyBackend {
   void Quit() override;
   void SetWindowSize(uint32_t window_id, int width, int height) override;
   void GetWindowSize(uint32_t window_id, int* width, int* height) override;
+  void GetWindowOuterSize(uint32_t window_id, int* width, int* height) override;
   double GetWindowScaleFactor(uint32_t window_id) override;
   void SetWindowPosition(uint32_t window_id, int x, int y) override;
   void GetWindowPosition(uint32_t window_id, int* x, int* y) override;
@@ -1506,6 +1507,24 @@ void WKWebViewBackend::GetWindowSize(uint32_t window_id, int* width,
           [state->window contentRectForFrameRect:[state->window frame]];
       w = static_cast<int>(content.size.width);
       h = static_cast<int>(content.size.height);
+    }
+  });
+  if (width)
+    *width = w;
+  if (height)
+    *height = h;
+}
+
+void WKWebViewBackend::GetWindowOuterSize(uint32_t window_id, int* width,
+                                          int* height) {
+  __block int w = 0, h = 0;
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      NSRect frame = [state->window frame];
+      w = static_cast<int>(frame.size.width);
+      h = static_cast<int>(frame.size.height);
     }
   });
   if (width)

--- a/webview/src/webview_windows.cc
+++ b/webview/src/webview_windows.cc
@@ -308,8 +308,10 @@ class WebView2Backend : public LaufeyBackend {
   void Quit() override;
   void SetWindowSize(uint32_t window_id, int width, int height) override;
   void GetWindowSize(uint32_t window_id, int* width, int* height) override;
+  double GetWindowScaleFactor(uint32_t window_id) override;
   void SetWindowPosition(uint32_t window_id, int x, int y) override;
   void GetWindowPosition(uint32_t window_id, int* x, int* y) override;
+  void GetWindowInnerPosition(uint32_t window_id, int* x, int* y) override;
   void SetResizable(uint32_t window_id, bool resizable) override;
   bool IsResizable(uint32_t window_id) override;
   void SetAlwaysOnTop(uint32_t window_id, bool always_on_top) override;
@@ -1146,6 +1148,15 @@ void WebView2Backend::SetWindowSize(uint32_t window_id, int width, int height) {
   }
 }
 
+double WebView2Backend::GetWindowScaleFactor(uint32_t window_id) {
+  std::lock_guard<std::recursive_mutex> lock(windows_mutex_);
+  auto* state = GetWindow(window_id);
+  if (!state)
+    return 1.0;
+  UINT dpi = GetDpiForWindow(state->hwnd);
+  return dpi > 0 ? dpi / 96.0 : 1.0;
+}
+
 void WebView2Backend::GetWindowSize(uint32_t window_id, int* width,
                                     int* height) {
   std::lock_guard<std::recursive_mutex> lock(windows_mutex_);
@@ -1171,6 +1182,21 @@ void WebView2Backend::SetWindowPosition(uint32_t window_id, int x, int y) {
   auto* state = GetWindow(window_id);
   if (state) {
     SetWindowPos(state->hwnd, nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
+  }
+}
+
+void WebView2Backend::GetWindowInnerPosition(uint32_t window_id, int* x,
+                                             int* y) {
+  std::lock_guard<std::recursive_mutex> lock(windows_mutex_);
+  auto* state = GetWindow(window_id);
+  if (!state)
+    return;
+  POINT pt = {0, 0};
+  if (ClientToScreen(state->hwnd, &pt)) {
+    if (x)
+      *x = pt.x;
+    if (y)
+      *y = pt.y;
   }
 }
 

--- a/webview/src/webview_windows.cc
+++ b/webview/src/webview_windows.cc
@@ -308,6 +308,7 @@ class WebView2Backend : public LaufeyBackend {
   void Quit() override;
   void SetWindowSize(uint32_t window_id, int width, int height) override;
   void GetWindowSize(uint32_t window_id, int* width, int* height) override;
+  void GetWindowOuterSize(uint32_t window_id, int* width, int* height) override;
   double GetWindowScaleFactor(uint32_t window_id) override;
   void SetWindowPosition(uint32_t window_id, int x, int y) override;
   void GetWindowPosition(uint32_t window_id, int* x, int* y) override;
@@ -1170,6 +1171,11 @@ void WebView2Backend::GetWindowSize(uint32_t window_id, int* width,
         *height = rect.bottom - rect.top;
     }
   }
+}
+
+void WebView2Backend::GetWindowOuterSize(uint32_t window_id, int* width,
+                                         int* height) {
+  GetWindowSize(window_id, width, height);
 }
 
 void WebView2Backend::SetWindowPosition(uint32_t window_id, int x, int y) {

--- a/winit/src/main.rs
+++ b/winit/src/main.rs
@@ -6,8 +6,8 @@ use std::ffi::c_void;
 use std::sync::atomic::{AtomicPtr, Ordering};
 
 use laufey_backend_winit_common::{
-  define_common_backend_fns, fill_common_api, winit, BackendAccess,
-  CommonEvent, CommonState, LaufeyBackendApi, LaufeyJsResultFn,
+  BackendAccess, CommonEvent, CommonState, LaufeyBackendApi, LaufeyJsResultFn,
+  define_common_backend_fns, fill_common_api, winit,
 };
 use winit::application::ApplicationHandler;
 use winit::dpi::{PhysicalPosition, PhysicalSize};
@@ -318,9 +318,23 @@ impl ApplicationHandler<UserEvent> for App {
         );
       }
       WindowEvent::CursorMoved { position, .. } => {
-        state.common.with_window(laufey_id, |ws| {
-          *ws.cursor_position.lock().unwrap() = (position.x, position.y);
-        });
+        let flush_enter = state
+          .common
+          .with_window(laufey_id, |ws| {
+            ws.note_cursor_move(position.x, position.y)
+          })
+          .unwrap_or(false);
+        if flush_enter {
+          state.common.with_window(laufey_id, |ws| {
+            laufey_backend_winit_common::dispatch_cursor_enter_leave_event(
+              &state.common.handlers,
+              ws,
+              laufey_id,
+              true,
+              *modifiers,
+            );
+          });
+        }
         laufey_backend_winit_common::dispatch_mouse_move_event(
           &state.common.handlers,
           laufey_id,
@@ -358,17 +372,20 @@ impl ApplicationHandler<UserEvent> for App {
       }
       WindowEvent::CursorEntered { .. } => {
         state.common.with_window(laufey_id, |ws| {
-          laufey_backend_winit_common::dispatch_cursor_enter_leave_event(
-            &state.common.handlers,
-            ws,
-            laufey_id,
-            true,
-            *modifiers,
-          );
+          if ws.note_cursor_entered() {
+            laufey_backend_winit_common::dispatch_cursor_enter_leave_event(
+              &state.common.handlers,
+              ws,
+              laufey_id,
+              true,
+              *modifiers,
+            );
+          }
         });
       }
       WindowEvent::CursorLeft { .. } => {
         state.common.with_window(laufey_id, |ws| {
+          ws.note_cursor_left();
           laufey_backend_winit_common::dispatch_cursor_enter_leave_event(
             &state.common.handlers,
             ws,

--- a/winit/src/main.rs
+++ b/winit/src/main.rs
@@ -11,9 +11,8 @@ use laufey_backend_winit_common::{
 };
 use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalSize, PhysicalPosition, PhysicalSize};
-use winit::event::WindowEvent;
+use winit::event::{Modifiers, WindowEvent};
 use winit::event_loop::{EventLoop, EventLoopProxy};
-use winit::keyboard::ModifiersState;
 use winit::window::Window;
 
 // --- Backend state ---
@@ -93,7 +92,7 @@ enum UserEvent {
 
 struct WindowInfo {
   window: Window,
-  modifiers: ModifiersState,
+  modifiers: Modifiers,
 }
 
 struct App {
@@ -152,7 +151,7 @@ impl App {
       window_id,
       WindowInfo {
         window,
-        modifiers: ModifiersState::default(),
+        modifiers: Modifiers::default(),
       },
     );
   }
@@ -267,7 +266,7 @@ impl ApplicationHandler<UserEvent> for App {
       None => return,
     };
     let modifiers = match self.windows.get(&laufey_id) {
-      Some(info) => info.modifiers,
+      Some(info) => info.modifiers.state(),
       None => return,
     };
 
@@ -351,20 +350,45 @@ impl ApplicationHandler<UserEvent> for App {
         );
       }
       WindowEvent::ModifiersChanged(new_modifiers) => {
+        let prev = self
+          .windows
+          .get(&laufey_id)
+          .map(|info| info.modifiers)
+          .unwrap_or_default();
         if let Some(info) = self.windows.get_mut(&laufey_id) {
-          info.modifiers = new_modifiers.state();
+          info.modifiers = new_modifiers;
+        }
+        // macOS often has no KeyboardInput for modifiers. Emit the same
+        // keydown/keyup CEF / WebView send. Skip KeyboardInput for those
+        // named keys so Windows / Linux do not double-fire.
+        for (pressed, key, code) in
+          laufey_backend_winit_common::modifier_key_edges(&prev, &new_modifiers)
+        {
+          laufey_backend_winit_common::dispatch_raw_keyboard_event(
+            &state.common.handlers,
+            laufey_id,
+            pressed,
+            key,
+            code,
+            new_modifiers.state(),
+            false,
+          );
         }
       }
       WindowEvent::KeyboardInput {
         event: ref key_event,
         ..
       } => {
-        laufey_backend_winit_common::dispatch_keyboard_event(
-          &state.common.handlers,
-          laufey_id,
-          key_event,
-          modifiers,
-        );
+        if !laufey_backend_winit_common::is_modifier_named_key(
+          &key_event.logical_key,
+        ) {
+          laufey_backend_winit_common::dispatch_keyboard_event(
+            &state.common.handlers,
+            laufey_id,
+            key_event,
+            modifiers,
+          );
+        }
       }
       WindowEvent::CursorMoved { position, .. } => {
         let (x, y) = laufey_backend_winit_common::physical_pos_to_logical_f64(

--- a/winit/src/main.rs
+++ b/winit/src/main.rs
@@ -6,11 +6,11 @@ use std::ffi::c_void;
 use std::sync::atomic::{AtomicPtr, Ordering};
 
 use laufey_backend_winit_common::{
-  BackendAccess, CommonEvent, CommonState, LaufeyBackendApi, LaufeyJsResultFn,
-  define_common_backend_fns, fill_common_api, winit,
+  define_common_backend_fns, fill_common_api, winit, BackendAccess,
+  CommonEvent, CommonState, LaufeyBackendApi, LaufeyJsResultFn,
 };
 use winit::application::ApplicationHandler;
-use winit::dpi::{PhysicalPosition, PhysicalSize};
+use winit::dpi::{LogicalSize, PhysicalPosition, PhysicalSize};
 use winit::event::WindowEvent;
 use winit::event_loop::{EventLoop, EventLoopProxy};
 use winit::keyboard::ModifiersState;
@@ -261,8 +261,13 @@ impl ApplicationHandler<UserEvent> for App {
       None => return,
     };
 
-    let modifiers = match self.windows.get_mut(&laufey_id) {
-      Some(info) => &mut info.modifiers,
+    // Scale before any mut borrow of `windows` (modifiers live next to Window).
+    let scale_factor = match self.windows.get(&laufey_id) {
+      Some(info) => info.window.scale_factor(),
+      None => return,
+    };
+    let modifiers = match self.windows.get(&laufey_id) {
+      Some(info) => info.modifiers,
       None => return,
     };
 
@@ -281,20 +286,62 @@ impl ApplicationHandler<UserEvent> for App {
         }
       }
       WindowEvent::Resized(PhysicalSize { width, height }) => {
-        state.common.with_window(laufey_id, |ws| {
-          *ws.current_size.lock().unwrap() =
-            Some((width as i32, height as i32));
+        let (width, height) =
+          laufey_backend_winit_common::physical_size_to_logical_i32(
+            width,
+            height,
+            scale_factor,
+          );
+        let inner = self.windows.get(&laufey_id).and_then(|info| {
+          info.window.inner_position().ok().map(|p| {
+            laufey_backend_winit_common::physical_pos_to_logical_i32(
+              p.x,
+              p.y,
+              scale_factor,
+            )
+          })
         });
-        laufey_backend_winit_common::dispatch_resize_event(
-          &state.common.handlers,
-          laufey_id,
-          width as i32,
-          height as i32,
-        );
+        let changed = state
+          .common
+          .with_window(laufey_id, |ws| {
+            let prev = *ws.current_size.lock().unwrap();
+            *ws.current_size.lock().unwrap() = Some((width, height));
+            *ws.current_scale.lock().unwrap() = scale_factor;
+            if let Some(inner) = inner {
+              *ws.current_inner_position.lock().unwrap() = Some(inner);
+            }
+            prev != Some((width, height))
+          })
+          .unwrap_or(true);
+        if changed {
+          laufey_backend_winit_common::dispatch_resize_event(
+            &state.common.handlers,
+            laufey_id,
+            width,
+            height,
+          );
+        }
       }
       WindowEvent::Moved(PhysicalPosition { x, y }) => {
+        let (x, y) = laufey_backend_winit_common::physical_pos_to_logical_i32(
+          x,
+          y,
+          scale_factor,
+        );
+        let inner = self.windows.get(&laufey_id).and_then(|info| {
+          info.window.inner_position().ok().map(|p| {
+            laufey_backend_winit_common::physical_pos_to_logical_i32(
+              p.x,
+              p.y,
+              scale_factor,
+            )
+          })
+        });
         state.common.with_window(laufey_id, |ws| {
           *ws.pending_position.lock().unwrap() = Some((x, y));
+          if let Some(inner) = inner {
+            *ws.current_inner_position.lock().unwrap() = Some(inner);
+          }
         });
         laufey_backend_winit_common::dispatch_move_event(
           &state.common.handlers,
@@ -304,7 +351,9 @@ impl ApplicationHandler<UserEvent> for App {
         );
       }
       WindowEvent::ModifiersChanged(new_modifiers) => {
-        *modifiers = new_modifiers.state();
+        if let Some(info) = self.windows.get_mut(&laufey_id) {
+          info.modifiers = new_modifiers.state();
+        }
       }
       WindowEvent::KeyboardInput {
         event: ref key_event,
@@ -314,15 +363,18 @@ impl ApplicationHandler<UserEvent> for App {
           &state.common.handlers,
           laufey_id,
           key_event,
-          *modifiers,
+          modifiers,
         );
       }
       WindowEvent::CursorMoved { position, .. } => {
+        let (x, y) = laufey_backend_winit_common::physical_pos_to_logical_f64(
+          position.x,
+          position.y,
+          scale_factor,
+        );
         let flush_enter = state
           .common
-          .with_window(laufey_id, |ws| {
-            ws.note_cursor_move(position.x, position.y)
-          })
+          .with_window(laufey_id, |ws| ws.note_cursor_move(x, y))
           .unwrap_or(false);
         if flush_enter {
           state.common.with_window(laufey_id, |ws| {
@@ -331,16 +383,16 @@ impl ApplicationHandler<UserEvent> for App {
               ws,
               laufey_id,
               true,
-              *modifiers,
+              modifiers,
             );
           });
         }
         laufey_backend_winit_common::dispatch_mouse_move_event(
           &state.common.handlers,
           laufey_id,
-          position.x,
-          position.y,
-          *modifiers,
+          x,
+          y,
+          modifiers,
         );
       }
       WindowEvent::MouseInput {
@@ -355,7 +407,7 @@ impl ApplicationHandler<UserEvent> for App {
             laufey_id,
             button_state,
             button,
-            *modifiers,
+            modifiers,
           );
         });
       }
@@ -366,7 +418,8 @@ impl ApplicationHandler<UserEvent> for App {
             ws,
             laufey_id,
             delta,
-            *modifiers,
+            modifiers,
+            scale_factor,
           );
         });
       }
@@ -378,7 +431,7 @@ impl ApplicationHandler<UserEvent> for App {
               ws,
               laufey_id,
               true,
-              *modifiers,
+              modifiers,
             );
           }
         });
@@ -391,7 +444,7 @@ impl ApplicationHandler<UserEvent> for App {
             ws,
             laufey_id,
             false,
-            *modifiers,
+            modifiers,
           );
         });
       }
@@ -406,6 +459,45 @@ impl ApplicationHandler<UserEvent> for App {
           laufey_id,
           focused,
         );
+      }
+      WindowEvent::ScaleFactorChanged {
+        scale_factor: new_scale,
+        mut inner_size_writer,
+      } => {
+        // Another monitor (or a DPI change) — keep the DIP size CEF / WebView
+        // keep. Physical pixels follow; a later `Resized` refreshes
+        // `current_size` with the new scale. Do not recompute logical from the
+        // still-old `inner_size()`, or a 2× → 1× move reports half the window.
+        let logical = state
+          .common
+          .with_window(laufey_id, |ws| *ws.current_size.lock().unwrap())
+          .flatten();
+        if let Some((w, h)) = logical {
+          state.common.with_window(laufey_id, |ws| {
+            *ws.current_scale.lock().unwrap() = new_scale;
+          });
+          let physical =
+            LogicalSize::new(w as f64, h as f64).to_physical(new_scale);
+          let _ = inner_size_writer.request_inner_size(physical);
+        } else if let Some(info) = self.windows.get(&laufey_id) {
+          let size = info.window.inner_size();
+          let (width, height) =
+            laufey_backend_winit_common::physical_size_to_logical_i32(
+              size.width,
+              size.height,
+              new_scale,
+            );
+          state.common.with_window(laufey_id, |ws| {
+            *ws.current_size.lock().unwrap() = Some((width, height));
+            *ws.current_scale.lock().unwrap() = new_scale;
+          });
+          laufey_backend_winit_common::dispatch_resize_event(
+            &state.common.handlers,
+            laufey_id,
+            width,
+            height,
+          );
+        }
       }
 
       WindowEvent::ThemeChanged(_) => {}
@@ -425,7 +517,6 @@ impl ApplicationHandler<UserEvent> for App {
       }
       WindowEvent::ActivationTokenDone { .. }
       | WindowEvent::AxisMotion { .. }
-      | WindowEvent::ScaleFactorChanged { .. }
       | WindowEvent::Occluded(_)
       | WindowEvent::RedrawRequested => {
         // wont implement

--- a/winit/src/main.rs
+++ b/winit/src/main.rs
@@ -234,6 +234,19 @@ impl ApplicationHandler<UserEvent> for App {
   }
 
   fn about_to_wait(&mut self, event_loop: &winit::event_loop::ActiveEventLoop) {
+    // The queue is drained, so any `Resized` burst from creating a window has
+    // been seen. Re-sync each window's cached geometry from the real window
+    // and start reporting resizes.
+    if let Some(state) = BackendState::get() {
+      for (laufey_id, info) in &self.windows {
+        state.common.with_window(*laufey_id, |ws| {
+          laufey_backend_winit_common::settle_creation_geometry(
+            ws,
+            &info.window,
+          );
+        });
+      }
+    }
     laufey_backend_winit_common::poll_menu_events();
     // The tray lives on the primary monitor (menu bar / taskbar); its scale
     // factor converts tray-icon's physical rect into the logical window space.
@@ -300,6 +313,14 @@ impl ApplicationHandler<UserEvent> for App {
             )
           })
         });
+        let outer = self.windows.get(&laufey_id).map(|info| {
+          let s = info.window.outer_size();
+          laufey_backend_winit_common::physical_size_to_logical_i32(
+            s.width,
+            s.height,
+            scale_factor,
+          )
+        });
         let changed = state
           .common
           .with_window(laufey_id, |ws| {
@@ -309,9 +330,16 @@ impl ApplicationHandler<UserEvent> for App {
             if let Some(inner) = inner {
               *ws.current_inner_position.lock().unwrap() = Some(inner);
             }
-            prev != Some((width, height))
+            if let Some(outer) = outer {
+              *ws.current_outer_size.lock().unwrap() = Some(outer);
+            }
+            // Creating a window emits several `Resized` events for sizes the
+            // app never asked for. Keep the cache current, but stay silent
+            // until `about_to_wait` has drained that burst.
+            *ws.resize_reporting_armed.lock().unwrap()
+              && prev != Some((width, height))
           })
-          .unwrap_or(true);
+          .unwrap_or(false);
         if changed {
           laufey_backend_winit_common::dispatch_resize_event(
             &state.common.handlers,
@@ -337,7 +365,10 @@ impl ApplicationHandler<UserEvent> for App {
           })
         });
         state.common.with_window(laufey_id, |ws| {
-          *ws.pending_position.lock().unwrap() = Some((x, y));
+          // The authoritative origin, not `pending_position` — that is a
+          // request waiting to be applied, and re-arming it here would make a
+          // later apply move the window back to wherever it was dragged from.
+          *ws.current_position.lock().unwrap() = Some((x, y));
           if let Some(inner) = inner {
             *ws.current_inner_position.lock().unwrap() = Some(inner);
           }
@@ -424,7 +455,17 @@ impl ApplicationHandler<UserEvent> for App {
         button,
         ..
       } => {
+        let window = self.windows.get(&laufey_id).map(|info| &info.window);
         state.common.with_window(laufey_id, |ws| {
+          // `MouseInput` carries no position, so make sure the cached one is
+          // not behind a move that has yet to be dequeued.
+          if let Some(window) = window {
+            laufey_backend_winit_common::refresh_cursor_position(
+              ws,
+              window,
+              scale_factor,
+            );
+          }
           laufey_backend_winit_common::dispatch_mouse_click_event(
             &state.common.handlers,
             ws,


### PR DESCRIPTION
## Summary

Two parts: align raw (winit) — and macOS WebView where it lagged — with CEF / WebView, and add the ABI 35 getters every backend was missing.

### Align raw with CEF / WebView

- `mouseenter` waits for a real cursor position
- Multi-clicks use the CEF Linux tracker, so `dblclick` can fire
- Wheel `deltaY` uses the DOM sign (positive = down)
- macOS WebView reuses the press `clickCount`, so `click.detail` is 1
- Windows re-reads the pointer before a press (`WM_*BUTTONDOWN` can beat the synthesized `WM_MOUSEMOVE`)
- `get_size`, `resize`, `get_position`, and cursor `x`/`y` are logical pixels, same as CEF / WebView and `set_size`
- Opening no longer fires `resize` twice; Windows intermediate sizes wait until the event loop is idle
- `get_window_position` is the real frame origin, not a consumed request
- Constructor-time `get_window_inner_position` offsets by the chrome on Windows and macOS
- Shift / Control / Alt / Meta emit `keydown` / `keyup` (`ModifiersChanged` on raw, `FlagsChanged` on macOS WebView)
- Super maps to Web `Meta`

### New getters (API 35)

New on every backend (winit, CEF, and WebView). Field order: `get_window_scale_factor`, `get_window_inner_position`, `get_window_outer_size`, `test_inject_input`. No bump beyond 34 → 35.

- `get_window_scale_factor` — `window.devicePixelRatio`. Honest in the constructor (seeded from the primary display, not `1`); updates when the window changes monitor. WebGPU surfaces from `get_size()` should use `size * get_window_scale_factor()`. A scale change is not `resize`
- `get_window_inner_position` — content-view origin, so `inner + client` is `MouseEvent.screenX` / `screenY`
- `get_window_outer_size` — `window.outerWidth` / `outerHeight`. Frameless matches `get_window_size`

## Related

https://github.com/denoland/deno/pull/36761

## AI Disclosure

This PR was drafted and filed by an AI assistant (Grok). I reviewed and edited it myself.