### PR TITLE
fix(macos): keep accessory apps alive after last window closes

### DIFF
--- a/examples/native_e2e/src/lib.rs
+++ b/examples/native_e2e/src/lib.rs
@@ -532,6 +532,20 @@ fn e2e_main() {
       tokio::time::sleep(std::time::Duration::from_secs(8)).await;
     }
 
+    // A menu-bar-only macOS app uses the Accessory activation policy. Closing
+    // its last transient window must not terminate the process: it still owns
+    // the status item and needs to be able to show a window later. This check
+    // deliberately closes `win`, the final remaining window, then proves this
+    // runtime is still alive on the next turn of the async executor.
+    #[cfg(target_os = "macos")]
+    {
+      laufey::set_dock_visible(false);
+      tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+      win.close();
+      tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+      check("accessory app survives closing its last window", true);
+    }
+
     // ---- shutdown --------------------------------------------------------
     // Decide the result and terminate immediately with a deterministic exit
     // code. We deliberately skip close()/quit(): tearing the window/webview

--- a/scripts/native-e2e-run.sh
+++ b/scripts/native-e2e-run.sh
@@ -52,9 +52,23 @@ if [ "$mode" = "--layer1" ]; then
   exec xvfb-run -a dbus-run-session -- "$driver" "$bin"
 fi
 
-# Layer 0: run the backend directly. On Linux, headless via Xvfb + a private
-# session bus (some tray impls need a session bus to even initialize).
+# Layer 0: capture output so an unexpected native termination cannot masquerade
+# as success merely because macOS reports an exit code of 0. On Linux, run
+# headless via Xvfb + a private session bus (some tray implementations need it).
 if is_linux; then
-  exec xvfb-run -a dbus-run-session -- "$bin"
+  set +e
+  output="$(xvfb-run -a dbus-run-session -- "$bin" 2>&1)"
+  status=$?
+  set -e
+else
+  set +e
+  output="$("$bin" 2>&1)"
+  status=$?
+  set -e
 fi
-exec "$bin"
+printf '%s\n' "$output"
+if ! grep -q '^\[e2e\] OVERALL ' <<<"$output"; then
+  echo "native e2e exited before reporting an overall result" >&2
+  exit 1
+fi
+exit "$status"

--- a/webview/src/main_mac.mm
+++ b/webview/src/main_mac.mm
@@ -134,7 +134,10 @@ void EnsureEditMenu(NSMenu* menubar) {
 }
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication*)sender {
-  return YES;
+  // A menu-bar-only app uses the Accessory activation policy. Its windows can
+  // be transient (for example, a tray popover), so closing the last one must
+  // not terminate the process and remove its status item.
+  return [sender activationPolicy] != NSApplicationActivationPolicyAccessory;
 }
 
 - (BOOL)applicationShouldHandleReopen:(NSApplication*)sender


### PR DESCRIPTION
On macOS, `set_dock_visible(false)` switches `NSApp` to the Accessory activation policy. The WebView app delegate currently terminates after the last window closes, which also removes a tray-only app despite its status item remaining its primary UI.

Keep the existing quit-on-last-window behavior for regular applications. Accessory applications now stay alive when transient windows, such as tray popovers, close.

Validation:
- `make fmt-check`
- macOS WebView backend build via CMake + Ninja
- `scripts/native-e2e-run.sh webview`, including the new accessory lifecycle regression test

Prepared with assistance from Codex.